### PR TITLE
Fix path alias in Jest and user route params

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,10 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig');
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "jsdom",
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  }),
 };

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -4,9 +4,9 @@ import { prisma } from "@lib/prisma";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const user = await prisma.user.findUnique({
       where: { id },
@@ -26,9 +26,9 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const body = await request.json();
     const updatedUser = await prisma.user.update({
@@ -47,9 +47,9 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     await prisma.user.delete({
       where: { id },


### PR DESCRIPTION
## Summary
- fix TypeScript path aliases for Jest so tests can run
- correct context param types in user API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f5b5256c8324a6398baf73276dba