### PR TITLE
Add unit tests

### DIFF
--- a/src/lib/api/__tests__/run.test.ts
+++ b/src/lib/api/__tests__/run.test.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { createRun, updateRun, getRun, deleteRun, listRuns } from '../run';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('run api helpers', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('createRun posts data', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: '1' } });
+    const data = { distance: 5 };
+    const result = await createRun(data);
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/runs', data);
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('updateRun puts data', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: '1', distance: 10 } });
+    const result = await updateRun('1', { distance: 10 });
+    expect(mockedAxios.put).toHaveBeenCalledWith('/api/runs/1', { distance: 10 });
+    expect(result).toEqual({ id: '1', distance: 10 });
+  });
+
+  it('getRun fetches data', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { id: '1' } });
+    const result = await getRun('1');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/runs/1');
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('deleteRun deletes data', async () => {
+    mockedAxios.delete.mockResolvedValue({ data: {} });
+    const result = await deleteRun('1');
+    expect(mockedAxios.delete).toHaveBeenCalledWith('/api/runs/1');
+    expect(result).toEqual({});
+  });
+
+  it('listRuns gets all runs', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [1,2] });
+    const result = await listRuns();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/runs');
+    expect(result).toEqual([1,2]);
+  });
+});

--- a/src/lib/utils/__tests__/calculatePace.test.ts
+++ b/src/lib/utils/__tests__/calculatePace.test.ts
@@ -1,0 +1,8 @@
+import calculatePace from "../running/calculatePace";
+
+describe("calculatePace", () => {
+  it("computes pace from duration and distance", () => {
+    expect(calculatePace("01:00:00", 10)).toBe("06:00");
+    expect(calculatePace("00:30:00", 5)).toBe("06:00");
+  });
+});

--- a/src/lib/utils/__tests__/calculateRacePaces.test.ts
+++ b/src/lib/utils/__tests__/calculateRacePaces.test.ts
@@ -1,0 +1,13 @@
+import { calculateRacePaces } from "../running/calculateRacePaces";
+
+describe("calculateRacePaces", () => {
+  it("returns predictions for standard distances", () => {
+    const results = calculateRacePaces(50, 10); // 10k in 50 mins
+    expect(results).toEqual([
+      { target: "5K", predictedTime: "23:59", pacePerKm: "4:48", pacePerMile: "7:43" },
+      { target: "10K", predictedTime: "50:00", pacePerKm: "5:00", pacePerMile: "8:03" },
+      { target: "Half Marathon", predictedTime: "1:50:19", pacePerKm: "5:14", pacePerMile: "8:25" },
+      { target: "Marathon", predictedTime: "3:50:01", pacePerKm: "5:27", pacePerMile: "8:46" },
+    ]);
+  });
+});

--- a/src/lib/utils/__tests__/calculateWeeklyMileage.test.ts
+++ b/src/lib/utils/__tests__/calculateWeeklyMileage.test.ts
@@ -1,0 +1,12 @@
+import { calculateWeeklyMileage } from "../running/calculateWeeklyMileage";
+
+describe("calculateWeeklyMileage", () => {
+  it("handles each training phase", () => {
+    const totalWeeks = 10;
+    const peak = 50;
+    expect(calculateWeeklyMileage(1, totalWeeks, peak)).toBe(28); // base
+    expect(calculateWeeklyMileage(5, totalWeeks, peak)).toBe(38); // build
+    expect(calculateWeeklyMileage(8, totalWeeks, peak)).toBe(50); // peak
+    expect(calculateWeeklyMileage(10, totalWeeks, peak)).toBe(25); // taper
+  });
+});

--- a/src/lib/utils/__tests__/getLocalDateTime.test.ts
+++ b/src/lib/utils/__tests__/getLocalDateTime.test.ts
@@ -1,0 +1,11 @@
+import { getLocalDateTime } from "../time";
+
+describe("getLocalDateTime", () => {
+  it("returns ISO datetime without timezone offset", () => {
+    const value = getLocalDateTime();
+    expect(value).toHaveLength(16);
+    expect(value).toMatch(/T/);
+    const asDate = new Date(value);
+    expect(asDate.toISOString().slice(0,16)).toBe(value);
+  });
+});

--- a/src/lib/utils/__tests__/lerp.test.ts
+++ b/src/lib/utils/__tests__/lerp.test.ts
@@ -1,0 +1,9 @@
+import lerp from "../math/lerp";
+
+describe("lerp", () => {
+  it("interpolates between start and end", () => {
+    expect(lerp(0, 10, 0)).toBe(0);
+    expect(lerp(0, 10, 1)).toBe(10);
+    expect(lerp(0, 10, 0.5)).toBe(5);
+  });
+});

--- a/src/lib/utils/__tests__/paceUtils.test.ts
+++ b/src/lib/utils/__tests__/paceUtils.test.ts
@@ -1,0 +1,19 @@
+import { parsePace, formatPace, getPacesFromRacePace } from "../running/paces";
+
+describe("pace utilities", () => {
+  it("parses and formats pace", () => {
+    expect(parsePace("5:30")).toBe(330);
+    expect(formatPace(330)).toBe("5:30");
+  });
+
+  it("calculates training paces from race pace", () => {
+    const paces = getPacesFromRacePace(330);
+    expect(paces).toEqual({
+      easy: "6:53",
+      marathon: "5:47",
+      threshold: "5:14",
+      interval: "4:57",
+      race: "5:30",
+    });
+  });
+});

--- a/src/lib/utils/__tests__/riegalCalculator.test.ts
+++ b/src/lib/utils/__tests__/riegalCalculator.test.ts
@@ -1,0 +1,12 @@
+import { riegalCalculator } from "../running/riegalCalculator";
+
+describe("riegalCalculator", () => {
+  it("predicts race performance", () => {
+    const result = riegalCalculator(3600, 10000, 21097.5);
+    expect(result).toEqual({
+      totalTimeSec: 7943,
+      pacePerKm: "6:16",
+      pacePerMile: "10:06",
+    });
+  });
+});

--- a/src/store/__tests__/userStore.test.ts
+++ b/src/store/__tests__/userStore.test.ts
@@ -1,0 +1,28 @@
+import { useUserStore } from '../userStore';
+
+interface User { id: string; name: string; email: string; }
+
+const sampleUser: User = { id: '1', name: 'Test', email: 't@test.com' } as any;
+
+describe('useUserStore', () => {
+  afterEach(() => {
+    useUserStore.setState({ user: null });
+  });
+
+  it('sets and retrieves user', () => {
+    useUserStore.getState().setUser(sampleUser as any);
+    expect(useUserStore.getState().user).toEqual(sampleUser);
+  });
+
+  it('updates user fields', () => {
+    useUserStore.getState().setUser(sampleUser as any);
+    useUserStore.getState().updateUser({ name: 'New' });
+    expect(useUserStore.getState().user?.name).toBe('New');
+  });
+
+  it('clears user', () => {
+    useUserStore.getState().setUser(sampleUser as any);
+    useUserStore.getState().clearUser();
+    expect(useUserStore.getState().user).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- test math lerp helper
- test pace utilities
- test calculatePace and weekly mileage logic
- add Riegel predictions and race pace tests
- cover getLocalDateTime utility
- test run API helpers with mocked axios
- test Zustand user store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f70ea2cc8324ac6ab879f1c508ba