### PR TITLE
Add editable running plans and saving

### DIFF
--- a/src/app/api/running-plans/[id]/route.ts
+++ b/src/app/api/running-plans/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const plan = await prisma.runningPlan.findUnique({ where: { id: params.id } });
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+    }
+    return NextResponse.json(plan, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching plan:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error fetching plan" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json();
+    const updated = await prisma.runningPlan.update({
+      where: { id: params.id },
+      data: body,
+    });
+    return NextResponse.json(updated, { status: 200 });
+  } catch (error) {
+    console.error("Error updating plan:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error updating plan" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await prisma.runningPlan.delete({ where: { id: params.id } });
+    return NextResponse.json({ message: "Plan deleted" }, { status: 200 });
+  } catch (error) {
+    console.error("Error deleting plan:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error deleting plan" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/running-plans/route.ts
+++ b/src/app/api/running-plans/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET() {
+  try {
+    const plans = await prisma.runningPlan.findMany();
+    return NextResponse.json(plans, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching plans:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error fetching plans" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { userId, weeks, planData } = body;
+
+    if (!userId) {
+      return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+    }
+
+    const newPlan = await prisma.runningPlan.create({
+      data: {
+        user: { connect: { id: userId } },
+        weeks: Number(weeks),
+        planData,
+      },
+    });
+
+    return NextResponse.json(newPlan, { status: 201 });
+  } catch (error) {
+    console.error("Error creating running plan:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error creating plan" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/PlanGenerator.tsx
+++ b/src/components/PlanGenerator.tsx
@@ -6,6 +6,7 @@ import ToggleSwitch from "./ToggleSwitch";
 import RunningPlanDisplay from "./RunningPlanDisplay";
 import { generateRunningPlan } from "@utils/running/plans/baseRunningPlan";
 import { RunningPlanData } from "@maratypes/runningPlan";
+import { createRunningPlan } from "@lib/api/plan";
 
 const DEFAULT_WEEKS = 16;
 const DEFAULT_DISTANCE = 26.2;
@@ -208,7 +209,31 @@ const PlanGenerator: React.FC = () => {
       )}
       {planData && (
         <div className="mt-6">
-          <RunningPlanDisplay planData={planData} />
+          <RunningPlanDisplay
+            planData={planData}
+            editable
+            onPlanChange={setPlanData}
+          />
+          <button
+            type="button"
+            onClick={async () => {
+              if (!user) return;
+              try {
+                await createRunningPlan({
+                  userId: user.id!,
+                  weeks: planData.weeks,
+                  planData,
+                });
+                alert("Plan saved");
+              } catch (err) {
+                console.error(err);
+                alert("Failed to save plan");
+              }
+            }}
+            className="mt-4 w-full bg-green-600 text-white p-2 rounded hover:bg-green-700"
+          >
+            Save Plan
+          </button>
           <div className="mt-4">
             <label className="flex items-center space-x-2">
               <input

--- a/src/components/RunningPlanDisplay.tsx
+++ b/src/components/RunningPlanDisplay.tsx
@@ -1,18 +1,40 @@
 import React, { useState } from "react";
 import { RunningPlanData, WeekPlan } from "@maratypes/runningPlan";
+import { parsePace, formatPace } from "@utils/running/paces";
 
 interface RunningPlanDisplayProps {
   planData: RunningPlanData;
+  editable?: boolean;
+  onPlanChange?: (plan: RunningPlanData) => void;
 }
 
 const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
   planData,
+  editable = false,
+  onPlanChange,
 }) => {
+  const updateRun = (weekIdx: number, runIdx: number, field: string, value: any) => {
+    if (!onPlanChange) return;
+    const newSchedule = planData.schedule.map((w, wi) => {
+      if (wi !== weekIdx) return w;
+      const runs = w.runs.map((r, ri) =>
+        ri === runIdx ? { ...r, [field]: value } : r
+      );
+      return { ...w, runs };
+    });
+    onPlanChange({ ...planData, schedule: newSchedule });
+  };
   return (
     <div className="container p-4">
       <h2 className="text-2xl font-bold text-center mb-4">Your Running Plan</h2>
-      {planData.schedule.map((weekPlan) => (
-        <CollapsibleWeek key={weekPlan.weekNumber} weekPlan={weekPlan} />
+      {planData.schedule.map((weekPlan, wi) => (
+        <CollapsibleWeek
+          key={weekPlan.weekNumber}
+          weekPlan={weekPlan}
+          editable={editable}
+          weekIndex={wi}
+          updateRun={updateRun}
+        />
       ))}
     </div>
   );
@@ -20,9 +42,17 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
 
 interface CollapsibleWeekProps {
   weekPlan: WeekPlan;
+  editable: boolean;
+  weekIndex: number;
+  updateRun: (weekIdx: number, runIdx: number, field: string, value: any) => void;
 }
 
-const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({ weekPlan }) => {
+const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
+  weekPlan,
+  editable,
+  weekIndex,
+  updateRun,
+}) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   return (
@@ -41,22 +71,71 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({ weekPlan }) => {
         <div className="p-4 bg-gray-400 text-gray-800">
           <ul className="space-y-3">
             {weekPlan.runs.map((run, index) => (
-              <li key={index} className="border-t border-gray-300 pt-2">
+              <li key={index} className="border-t border-gray-300 pt-2 space-y-1">
                 <p>
                   <strong>Type:</strong>{" "}
                   {run.type.charAt(0).toUpperCase() + run.type.slice(1)}
                 </p>
-                <p>
-                  <strong>Mileage:</strong> {run.mileage} {run.unit}
-                </p>
-                <p>
-                  <strong>Target Pace:</strong> {run.targetPace.pace} per{" "}
-                  {run.targetPace.unit}
-                </p>
-                {run.notes && (
-                  <p>
-                    <strong>Notes:</strong> {run.notes}
-                  </p>
+                {editable ? (
+                  <div className="space-y-1">
+                    <label className="block">
+                      <span className="mr-2">Mileage:</span>
+                      <input
+                        type="number"
+                        step="0.1"
+                        value={run.mileage}
+                        onChange={(e) =>
+                          updateRun(
+                            weekIndex,
+                            index,
+                            "mileage",
+                            Math.round(Number(e.target.value) * 10) / 10
+                          )
+                        }
+                        className="border p-1 rounded text-black"
+                      />
+                      <span className="ml-1">{run.unit}</span>
+                    </label>
+                    <label className="block">
+                      <span className="mr-2">Target Pace:</span>
+                      <input
+                        type="text"
+                        value={run.targetPace.pace}
+                        onChange={(e) =>
+                          updateRun(weekIndex, index, "targetPace", {
+                            ...run.targetPace,
+                            pace: formatPace(parsePace(e.target.value)),
+                          })
+                        }
+                        className="border p-1 rounded text-black"
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="mr-2">Notes:</span>
+                      <input
+                        type="text"
+                        value={run.notes || ""}
+                        onChange={(e) =>
+                          updateRun(weekIndex, index, "notes", e.target.value)
+                        }
+                        className="border p-1 rounded text-black w-full"
+                      />
+                    </label>
+                  </div>
+                ) : (
+                  <>
+                    <p>
+                      <strong>Mileage:</strong> {run.mileage} {run.unit}
+                    </p>
+                    <p>
+                      <strong>Target Pace:</strong> {run.targetPace.pace} per {run.targetPace.unit}
+                    </p>
+                    {run.notes && (
+                      <p>
+                        <strong>Notes:</strong> {run.notes}
+                      </p>
+                    )}
+                  </>
                 )}
               </li>
             ))}

--- a/src/lib/api/plan/index.ts
+++ b/src/lib/api/plan/index.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { RunningPlan } from "@maratypes/runningPlan";
+
+export const createRunningPlan = async (data: Partial<RunningPlan>) => {
+  const response = await axios.post(`/api/running-plans`, data);
+  return response.data;
+};
+
+export const updateRunningPlan = async (id: string, data: Partial<RunningPlan>) => {
+  const response = await axios.put(`/api/running-plans/${id}`, data);
+  return response.data;
+};
+
+export const getRunningPlan = async (id: string) => {
+  const response = await axios.get(`/api/running-plans/${id}`);
+  return response.data;
+};
+
+export const deleteRunningPlan = async (id: string) => {
+  const response = await axios.delete(`/api/running-plans/${id}`);
+  return response.data;
+};
+
+export const listRunningPlans = async () => {
+  const response = await axios.get(`/api/running-plans`);
+  return response.data;
+};

--- a/src/lib/utils/__tests__/paceUtils.test.ts
+++ b/src/lib/utils/__tests__/paceUtils.test.ts
@@ -9,10 +9,10 @@ describe("pace utilities", () => {
   it("calculates training paces from race pace", () => {
     const paces = getPacesFromRacePace(330);
     expect(paces).toEqual({
-      easy: "6:53",
-      marathon: "5:47",
-      threshold: "5:14",
-      interval: "4:57",
+      easy: "7:00",
+      marathon: "5:45",
+      threshold: "5:15",
+      interval: "5:00",
       race: "5:30",
     });
   });

--- a/src/lib/utils/running/paces/index.ts
+++ b/src/lib/utils/running/paces/index.ts
@@ -4,8 +4,10 @@ export function parsePace(pace: string): number {
 }
 
 export function formatPace(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = Math.round(seconds % 60);
+  const interval = 15;
+  const rounded = Math.round(seconds / interval) * interval;
+  const m = Math.floor(rounded / 60);
+  const s = Math.round(rounded % 60);
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 


### PR DESCRIPTION
## Summary
- add API routes for running plans
- expose running plan API helpers
- round paces to nearest 15s
- allow editing and saving of generated plans
- update tests for new rounding logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840fcaa8d148324a42c93335ff92309