### PR TITLE
Fix plan creation weeks handling and add API tests

### DIFF
--- a/src/app/api/running-plans/route.ts
+++ b/src/app/api/running-plans/route.ts
@@ -23,10 +23,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "User ID is required" }, { status: 400 });
     }
 
+    const derivedWeeks =
+      weeks ?? planData?.weeks ?? planData?.schedule?.length ?? null;
+
+    if (derivedWeeks === null || Number.isNaN(Number(derivedWeeks))) {
+      return NextResponse.json({ error: "Weeks is required" }, { status: 400 });
+    }
+
     const newPlan = await prisma.runningPlan.create({
       data: {
         user: { connect: { id: userId } },
-        weeks: Number(weeks),
+        weeks: Number(derivedWeeks),
         planData,
       },
     });

--- a/src/lib/api/__tests__/plan.test.ts
+++ b/src/lib/api/__tests__/plan.test.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { createRunningPlan, updateRunningPlan, getRunningPlan, deleteRunningPlan, listRunningPlans } from '../plan';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('plan api helpers', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('createRunningPlan posts data', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: '1' } });
+    const data = { userId: 'u1', planData: { weeks: 1, schedule: [] } };
+    const result = await createRunningPlan(data as any);
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/running-plans', data);
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('updateRunningPlan puts data', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: '1' } });
+    const result = await updateRunningPlan('1', { planData: { weeks: 2, schedule: [] } } as any);
+    expect(mockedAxios.put).toHaveBeenCalledWith('/api/running-plans/1', { planData: { weeks: 2, schedule: [] } });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('getRunningPlan fetches data', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { id: '1' } });
+    const result = await getRunningPlan('1');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/running-plans/1');
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('deleteRunningPlan deletes data', async () => {
+    mockedAxios.delete.mockResolvedValue({ data: {} });
+    const result = await deleteRunningPlan('1');
+    expect(mockedAxios.delete).toHaveBeenCalledWith('/api/running-plans/1');
+    expect(result).toEqual({});
+  });
+
+  it('listRunningPlans gets all plans', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [1, 2] });
+    const result = await listRunningPlans();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/running-plans');
+    expect(result).toEqual([1, 2]);
+  });
+});

--- a/src/lib/api/__tests__/shoe.test.ts
+++ b/src/lib/api/__tests__/shoe.test.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { createShoe, updateShoe, getShoe, deleteShoe, listShoes } from '../shoe';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('shoe api helpers', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('createShoe posts data', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: '1' } });
+    const data = { name: 'shoe' };
+    const result = await createShoe(data as any);
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/shoes', data);
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('updateShoe puts data', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: '1' } });
+    const result = await updateShoe('1', { name: 'new' } as any);
+    expect(mockedAxios.put).toHaveBeenCalledWith('/api/shoes/1', { name: 'new' });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('getShoe fetches data', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { id: '1' } });
+    const result = await getShoe('1');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/shoes/1');
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('deleteShoe deletes data', async () => {
+    mockedAxios.delete.mockResolvedValue({ data: {} });
+    const result = await deleteShoe('1');
+    expect(mockedAxios.delete).toHaveBeenCalledWith('/api/shoes/1');
+    expect(result).toEqual({});
+  });
+
+  it('listShoes gets all shoes', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [1, 2] });
+    const result = await listShoes();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/shoes');
+    expect(result).toEqual([1, 2]);
+  });
+});

--- a/src/lib/api/__tests__/user.test.ts
+++ b/src/lib/api/__tests__/user.test.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import { updateUserProfile, createUserProfile, getUserProfile } from '../user/user';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('user api helpers', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('updateUserProfile puts data', async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: '1' } });
+    const result = await updateUserProfile('1', { name: 'joe' } as any);
+    expect(mockedAxios.put).toHaveBeenCalledWith('/api/users/1', { name: 'joe' });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('createUserProfile posts data', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: '1' } });
+    const data = { name: 'joe' };
+    const result = await createUserProfile(data as any);
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/users', data);
+    expect(result).toEqual({ data: { id: '1' } });
+  });
+
+  it('getUserProfile fetches data', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { id: '1' } });
+    const result = await getUserProfile('1');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/users/1');
+    expect(result).toEqual({ id: '1' });
+  });
+});


### PR DESCRIPTION
## Summary
- validate weeks field when creating running plan
- infer weeks from planData when not provided
- add tests for running plan, shoe, and user API helpers

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68422958e06483249ef151cef56e1dfc