### PR TITLE
Add default unit fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,8 @@ model User {
   preferredTrainingDays        DayOfWeek[]
   preferredTrainingEnvironment TrainingEnvironment?
   device                       Device?
+  defaultDistanceUnit          DistanceUnit?       @default(miles)
+  defaultElevationUnit         elevationGainUnit?  @default(feet)
   createdAt                    DateTime            @default(now())
   updatedAt                    DateTime            @updatedAt
 


### PR DESCRIPTION
## Summary
- include defaultDistanceUnit and defaultElevationUnit fields in the User model

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68422b51282c8324aa515ef410cb0865