### PR TITLE
Add user home page

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,61 +1,60 @@
-// src/app/page.tsx
+"use client";
+
 import Link from "next/link";
+import { useSession } from "next-auth/react";
+import RecentRuns from "@components/RecentRuns";
+import TrainingPlansList from "@components/TrainingPlansList";
 
 export default function HomePage() {
-  return (
-    <main className="min-h-screen bg-background text-foreground">
-      {/* Hero Section */}
-      <section className="flex flex-col items-center justify-center py-16 px-4 text-center">
-        <h1 className="text-5xl font-bold mb-4">Welcome to Maratron</h1>
-        <p className="text-xl mb-8">
-          Your AI running coach for optimized coaching, training planning, and
-          run recording.
-        </p>
-        <Link
-          href="/signup"
-          className="inline-block px-6 py-3 bg-primary text-white rounded hover:bg-primary-dark transition-colors"
-        >
-          Get Started
-        </Link>
-      </section>
+  const { data: session, status } = useSession();
 
-      {/* Features Section */}
-      <section className="py-12 px-4">
-        <h2 className="text-3xl font-bold text-center mb-8">Features</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="p-6 border rounded shadow-sm">
-            <h3 className="text-xl font-semibold mb-2">Optimized Coaching</h3>
-            <p>
-              Receive personalized coaching based on your performance and
-              running data.
-            </p>
-          </div>
-          <div className="p-6 border rounded shadow-sm">
-            <h3 className="text-xl font-semibold mb-2">Training Planning</h3>
-            <p>
-              Build smart, adaptive training plans tailored to your fitness
-              level and goals.
-            </p>
-          </div>
-          <div className="p-6 border rounded shadow-sm">
-            <h3 className="text-xl font-semibold mb-2">Run Recording</h3>
-            <p>
-              Log and analyze your runs with detailed metrics to track your
-              progress.
-            </p>
-          </div>
+  if (status === "loading") {
+    return <main className="p-6">Loading...</main>;
+  }
+
+  if (!session?.user) {
+    return (
+      <main className="min-h-screen flex flex-col items-center justify-center p-4 text-center">
+        <h1 className="text-4xl font-bold mb-4">Welcome to Maratron</h1>
+        <p className="mb-6">Please <Link href="/login" className="underline text-primary">sign in</Link> to access your dashboard.</p>
+      </main>
+    );
+  }
+
+  const userName = session.user.name || session.user.email;
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-4 space-y-10">
+      <h1 className="text-3xl font-bold">Welcome back, {userName}!</h1>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Quick Actions</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <Link href="/runs/new" className="border rounded p-4 hover:bg-accent/20">
+            Add a Run
+          </Link>
+          <Link href="/plan-generator" className="border rounded p-4 hover:bg-accent/20">
+            Generate Training Plan
+          </Link>
+          <Link href="/shoes/new" className="border rounded p-4 hover:bg-accent/20">
+            Add New Shoes
+          </Link>
+          <Link href="/userProfile" className="border rounded p-4 hover:bg-accent/20">
+            Edit Profile
+          </Link>
+          <div className="border rounded p-4 text-gray-500">Upload workout file (coming soon)</div>
+          <div className="border rounded p-4 text-gray-500">View progress analytics (coming soon)</div>
         </div>
       </section>
 
-      {/* About Section */}
-      <section className="py-12 px-4 bg-accent">
-        <h2 className="text-3xl font-bold text-center mb-8">Why Maratron?</h2>
-        <p className="max-w-3xl mx-auto text-lg text-center">
-          Maratron leverages advanced AI algorithms to provide coaching and
-          training insights that evolve with you. Whether you&aposre a beginner
-          or a seasoned runner, our app adapts to your needs, ensuring every run
-          counts.
-        </p>
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Recent Runs</h2>
+        <RecentRuns />
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Your Training Plan</h2>
+        <TrainingPlansList />
       </section>
     </main>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -26,8 +26,8 @@ const LoginPage: React.FC = () => {
       return;
     }
 
-    // On successful login, redirect to home page
-    router.push("/");
+    // On successful login, redirect to the user home page
+    router.push("/home");
   };
 
   // Show loading state while NextAuth checks session (optional)
@@ -48,7 +48,7 @@ const LoginPage: React.FC = () => {
         </div>
         <div className="flex justify-center">
           <button
-            onClick={() => router.push("/")}
+            onClick={() => router.push("/home")}
             className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
           >
             Go Home

--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { getRunningPlan } from "@lib/api/plan";
+import type { RunningPlan } from "@maratypes/runningPlan";
+import RunningPlanDisplay from "@components/RunningPlanDisplay";
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default function PlanPage({ params }: PageProps) {
+  const { data: session, status } = useSession();
+  const [plan, setPlan] = useState<RunningPlan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchPlan = async () => {
+      try {
+        const fetched: RunningPlan = await getRunningPlan(params.id);
+        if (session?.user && fetched.userId !== session.user.id) {
+          router.push("/home");
+          return;
+        }
+        setPlan(fetched);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPlan();
+  }, [params.id, session?.user, router]);
+
+  if (status === "loading" || loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  if (!plan) {
+    return <div className="p-4">Plan not found.</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Training Plan</h1>
+      <RunningPlanDisplay planData={plan.planData} />
+    </div>
+  );
+}

--- a/src/components/RecentRuns.tsx
+++ b/src/components/RecentRuns.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { listRuns } from "@lib/api/run";
+import type { Run } from "@maratypes/run";
+
+export default function RecentRuns() {
+  const { data: session } = useSession();
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRuns = async () => {
+      try {
+        const allRuns: Run[] = await listRuns();
+        const userId = session?.user?.id;
+        let filtered = allRuns;
+        if (userId) {
+          filtered = allRuns.filter((r) => r.userId === userId);
+        }
+        filtered.sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+        );
+        setRuns(filtered.slice(0, 5));
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRuns();
+  }, [session?.user?.id]);
+
+  if (loading) return <p className="text-gray-500">Loading runs...</p>;
+  if (runs.length === 0)
+    return <p className="text-gray-500">No runs recorded yet.</p>;
+
+  return (
+    <ul className="space-y-2">
+      {runs.map((run) => (
+        <li key={run.id} className="border p-2 rounded">
+          <span className="font-semibold">
+            {new Date(run.date).toLocaleDateString()}
+          </span>
+          {`: ${run.distance} ${run.distanceUnit}`}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { listRunningPlans } from "@lib/api/plan";
+import type { RunningPlan } from "@maratypes/runningPlan";
+
+export default function TrainingPlansList() {
+  const { data: session } = useSession();
+  const [plans, setPlans] = useState<RunningPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      try {
+        const allPlans: RunningPlan[] = await listRunningPlans();
+        const userId = session?.user?.id;
+        let filtered = allPlans;
+        if (userId) {
+          filtered = allPlans.filter((p) => p.userId === userId);
+        }
+        filtered.sort(
+          (a, b) =>
+            new Date(b.createdAt ?? "").getTime() -
+            new Date(a.createdAt ?? "").getTime()
+        );
+        setPlans(filtered);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPlans();
+  }, [session?.user?.id]);
+
+  if (loading) return <p className="text-gray-500">Loading plans...</p>;
+  if (plans.length === 0)
+    return <p className="text-gray-500">No plans saved.</p>;
+
+  return (
+    <ul className="space-y-2">
+      {plans.map((plan) => (
+        <li key={plan.id} className="border p-2 rounded">
+          <Link href={`/plans/${plan.id ?? ""}`} className="block">
+            <span className="font-semibold">
+              {plan.createdAt
+                ? new Date(plan.createdAt).toLocaleDateString()
+                : "Unnamed Plan"}
+            </span>
+            {plan.planData?.weeks && ` - ${plan.planData.weeks} weeks`}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- replace marketing home page with authenticated dashboard
- update login redirect to go to `/home`
- show recent runs and saved plans on user home
- add plan detail view under `/plans/[id]`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842699e032c8324be24d3133dda264e