### PR TITLE
Add run details view and compact quick actions

### DIFF
--- a/src/app/(auth)/runs/[id]/page.tsx
+++ b/src/app/(auth)/runs/[id]/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getRun } from "@lib/api/run";
+import type { Run } from "@maratypes/run";
+
+export default function RunDetailPage({ params }: { params: { id: string } }) {
+  const [run, setRun] = useState<Run | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRun = async () => {
+      try {
+        const fetched: Run = await getRun(params.id);
+        setRun(fetched);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRun();
+  }, [params.id]);
+
+  if (loading) return <div className="p-4">Loading...</div>;
+  if (!run) return <div className="p-4">Run not found.</div>;
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold mb-4">Run Details</h1>
+      <p>
+        <span className="font-semibold">Date:</span>{" "}
+        {new Date(run.date).toLocaleString()}
+      </p>
+      <p>
+        <span className="font-semibold">Distance:</span>{" "}
+        {run.distance} {run.distanceUnit}
+      </p>
+      <p>
+        <span className="font-semibold">Duration:</span>{" "}
+        {run.duration}
+      </p>
+      {run.trainingEnvironment && (
+        <p>
+          <span className="font-semibold">Environment:</span>{" "}
+          {run.trainingEnvironment}
+        </p>
+      )}
+      {run.elevationGain && (
+        <p>
+          <span className="font-semibold">Elevation Gain:</span>{" "}
+          {run.elevationGain} {run.elevationGainUnit}
+        </p>
+      )}
+      {run.notes && (
+        <p>
+          <span className="font-semibold">Notes:</span> {run.notes}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -30,21 +30,37 @@ export default function HomePage() {
 
       <section>
         <h2 className="text-2xl font-semibold mb-4">Quick Actions</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <Link href="/runs/new" className="border rounded p-4 hover:bg-accent/20">
+        <div className="flex flex-wrap gap-4">
+          <Link
+            href="/runs/new"
+            className="border rounded p-4 hover:bg-accent/20 w-40 text-center"
+          >
             Add a Run
           </Link>
-          <Link href="/plan-generator" className="border rounded p-4 hover:bg-accent/20">
-            Generate Training Plan
+          <Link
+            href="/plan-generator"
+            className="border rounded p-4 hover:bg-accent/20 w-40 text-center"
+          >
+            Generate Plan
           </Link>
-          <Link href="/shoes/new" className="border rounded p-4 hover:bg-accent/20">
-            Add New Shoes
+          <Link
+            href="/shoes/new"
+            className="border rounded p-4 hover:bg-accent/20 w-40 text-center"
+          >
+            Add Shoes
           </Link>
-          <Link href="/userProfile" className="border rounded p-4 hover:bg-accent/20">
+          <Link
+            href="/userProfile"
+            className="border rounded p-4 hover:bg-accent/20 w-40 text-center"
+          >
             Edit Profile
           </Link>
-          <div className="border rounded p-4 text-gray-500">Upload workout file (coming soon)</div>
-          <div className="border rounded p-4 text-gray-500">View progress analytics (coming soon)</div>
+          <div className="border rounded p-4 text-gray-500 w-40 text-center">
+            Upload file (soon)
+          </div>
+          <div className="border rounded p-4 text-gray-500 w-40 text-center">
+            Analytics (soon)
+          </div>
         </div>
       </section>
 

--- a/src/components/RecentRuns.tsx
+++ b/src/components/RecentRuns.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { listRuns } from "@lib/api/run";
 import type { Run } from "@maratypes/run";
@@ -40,11 +41,13 @@ export default function RecentRuns() {
   return (
     <ul className="space-y-2">
       {runs.map((run) => (
-        <li key={run.id} className="border p-2 rounded">
-          <span className="font-semibold">
-            {new Date(run.date).toLocaleDateString()}
-          </span>
-          {`: ${run.distance} ${run.distanceUnit}`}
+        <li key={run.id} className="border p-2 rounded hover:bg-accent/20">
+          <Link href={`/runs/${run.id}`} className="block">
+            <span className="font-semibold">
+              {new Date(run.date).toLocaleDateString()}
+            </span>
+            {`: ${run.distance} ${run.distanceUnit}`}
+          </Link>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- make quick action links small so several fit in a row
- show recent runs as links
- add new route to display details about a run

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: many type errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684271d1d450832485f628aa855808f0