### PR TITLE
Fix pace mapping for RecentRuns

### DIFF
--- a/src/lib/api/__tests__/run.test.ts
+++ b/src/lib/api/__tests__/run.test.ts
@@ -23,10 +23,28 @@ describe('run api helpers', () => {
   });
 
   it('getRun fetches data', async () => {
-    mockedAxios.get.mockResolvedValue({ data: { id: '1' } });
+    const apiRun = {
+      id: '1',
+      date: '2024-01-01T00:00:00.000Z',
+      duration: '00:30:00',
+      distance: 5,
+      distanceUnit: 'miles',
+      pace: '06:00',
+      paceUnit: 'miles',
+      userId: 'user1',
+    };
+    mockedAxios.get.mockResolvedValue({ data: apiRun });
     const result = await getRun('1');
     expect(mockedAxios.get).toHaveBeenCalledWith('/api/runs/1');
-    expect(result).toEqual({ id: '1' });
+    expect(result).toEqual({
+      id: '1',
+      date: new Date(apiRun.date),
+      duration: '00:30:00',
+      distance: 5,
+      distanceUnit: 'miles',
+      pace: { pace: '06:00', unit: 'miles' },
+      userId: 'user1',
+    });
   });
 
   it('deleteRun deletes data', async () => {
@@ -37,9 +55,29 @@ describe('run api helpers', () => {
   });
 
   it('listRuns gets all runs', async () => {
-    mockedAxios.get.mockResolvedValue({ data: [1,2] });
+    const apiRun = {
+      id: '1',
+      date: '2024-01-01T00:00:00.000Z',
+      duration: '00:30:00',
+      distance: 5,
+      distanceUnit: 'miles',
+      pace: '06:00',
+      paceUnit: 'miles',
+      userId: 'user1',
+    };
+    mockedAxios.get.mockResolvedValue({ data: [apiRun] });
     const result = await listRuns();
     expect(mockedAxios.get).toHaveBeenCalledWith('/api/runs');
-    expect(result).toEqual([1,2]);
+    expect(result).toEqual([
+      {
+        id: '1',
+        date: new Date(apiRun.date),
+        duration: '00:30:00',
+        distance: 5,
+        distanceUnit: 'miles',
+        pace: { pace: '06:00', unit: 'miles' },
+        userId: 'user1',
+      },
+    ]);
   });
 });

--- a/src/lib/api/run/index.ts
+++ b/src/lib/api/run/index.ts
@@ -1,6 +1,25 @@
 import axios from "axios";
 import { Run } from "@maratypes/run";
 
+// helper to map API response to Run type
+const mapRun = (data: any): Run => ({
+  id: data.id,
+  date: new Date(data.date),
+  duration: data.duration,
+  distance: data.distance,
+  distanceUnit: data.distanceUnit,
+  trainingEnvironment: data.trainingEnvironment ?? undefined,
+  pace:
+    data.pace && data.paceUnit
+      ? { pace: data.pace, unit: data.paceUnit }
+      : undefined,
+  elevationGain: data.elevationGain ?? undefined,
+  elevationGainUnit: data.elevationGainUnit ?? undefined,
+  notes: data.notes ?? undefined,
+  userId: data.userId,
+  shoeId: data.shoeId ?? undefined,
+});
+
 // Create a new run
 export const createRun = async (data: Partial<Run>) => {
   const response = await axios.post(`/api/runs`, data);
@@ -16,7 +35,7 @@ export const updateRun = async (runId: string, data: Partial<Run>) => {
 // Get a specific run by ID
 export const getRun = async (runId: string) => {
   const response = await axios.get(`/api/runs/${runId}`);
-  return response.data;
+  return mapRun(response.data);
 };
 
 // Delete a run by ID
@@ -28,5 +47,5 @@ export const deleteRun = async (runId: string) => {
 // List all runs (or you can extend this with filters as needed)
 export const listRuns = async () => {
   const response = await axios.get(`/api/runs`);
-  return response.data;
+  return (response.data as any[]).map(mapRun);
 };


### PR DESCRIPTION
## Summary
- map API run data into client `Run` shape so pace renders correctly
- adjust tests for run API helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684344131158832499012a6d2dfbfdf3