### PR TITLE
Allow naming plans and runs

### DIFF
--- a/prisma/migrations/20250708120000_add_names/migration.sql
+++ b/prisma/migrations/20250708120000_add_names/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "RunningPlans" ADD COLUMN "name" TEXT NOT NULL DEFAULT 'Training Plan';
+ALTER TABLE "Runs" ADD COLUMN "name" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,7 @@ model Run {
   distance            Float
   distanceUnit        DistanceUnit
   trainingEnvironment TrainingEnvironment?
+  name                String?
   pace                String?
   paceUnit            DistanceUnit?
   elevationGain       Float?
@@ -145,6 +146,7 @@ model Run {
 model RunningPlan {
   id        String   @id @default(uuid())
   userId    String
+  name      String
   weeks     Int
   planData  Json
   createdAt DateTime @default(now())

--- a/src/app/api/running-plans/route.ts
+++ b/src/app/api/running-plans/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { userId, weeks, planData } = body;
+    const { userId, weeks, planData, name } = body;
 
     if (!userId) {
       return NextResponse.json({ error: "User ID is required" }, { status: 400 });
@@ -30,11 +30,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Weeks is required" }, { status: 400 });
     }
 
+    const count = await prisma.runningPlan.count({ where: { userId } });
+    const defaultName = `Training Plan ${count + 1}`;
+
     const newPlan = await prisma.runningPlan.create({
       data: {
         user: { connect: { id: userId } },
         weeks: Number(derivedWeeks),
         planData,
+        name: name || defaultName,
       },
     });
 

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const {
+  const {
       date,
       duration,
       distance,
@@ -31,7 +31,8 @@ export async function POST(request: NextRequest) {
       notes,
       userId,
       shoeId,
-    } = body;
+      name,
+  } = body;
 
     const newRun = await prisma.run.create({
       data: {
@@ -40,6 +41,7 @@ export async function POST(request: NextRequest) {
         distance: Number(distance),
         distanceUnit,
         trainingEnvironment: trainingEnvironment || null,
+        name: name || `${new Date(date).toLocaleDateString()} ${new Date(date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}${trainingEnvironment ? ` - ${trainingEnvironment}` : ''}`,
         pace: pace ? pace.pace : null,
         paceUnit: pace ? pace.unit : null,
         elevationGain: elevationGain ? Number(elevationGain) : null,

--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -46,7 +46,7 @@ export default function PlanPage({ params }: PageProps) {
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Training Plan</h1>
+      <h1 className="text-2xl font-bold mb-4">{plan.name}</h1>
       <RunningPlanDisplay planData={plan.planData} />
     </div>
   );

--- a/src/components/PlanGenerator.tsx
+++ b/src/components/PlanGenerator.tsx
@@ -6,7 +6,7 @@ import ToggleSwitch from "./ToggleSwitch";
 import RunningPlanDisplay from "./RunningPlanDisplay";
 import { generateRunningPlan } from "@utils/running/plans/baseRunningPlan";
 import { RunningPlanData } from "@maratypes/runningPlan";
-import { createRunningPlan } from "@lib/api/plan";
+import { createRunningPlan, listRunningPlans } from "@lib/api/plan";
 
 const DEFAULT_WEEKS = 16;
 const DEFAULT_DISTANCE = 26.2;
@@ -31,10 +31,25 @@ const PlanGenerator: React.FC = () => {
   const [planData, setPlanData] = useState<RunningPlanData | null>(null);
   const [showJson, setShowJson] = useState<boolean>(false);
   const [editPlan, setEditPlan] = useState<boolean>(false);
+  const [planName, setPlanName] = useState<string>("Training Plan 1");
 
   const [trainingLevel, setTrainingLevel] = useState<TrainingLevel>(
     TrainingLevel.Beginner
   );
+
+  useEffect(() => {
+    const fetchName = async () => {
+      if (!user?.id) return;
+      try {
+        const all = await listRunningPlans();
+        const count = all.filter((p: any) => p.userId === user.id).length;
+        setPlanName(`Training Plan ${count + 1}`);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchName();
+  }, [user?.id]);
   // const [defaultShoeId, setDefaultShoeId] = useState<string | undefined>(
   //   undefined
   // );
@@ -212,6 +227,15 @@ const PlanGenerator: React.FC = () => {
       {planData && (
         <div className="mt-6">
           <h2 className="text-2xl font-bold text-center mb-4">Running Plan:</h2>
+          <div className="mb-4">
+            <label className="block mb-1 font-semibold">Plan Name</label>
+            <input
+              type="text"
+              value={planName}
+              onChange={(e) => setPlanName(e.target.value)}
+              className="border p-2 rounded w-full"
+            />
+          </div>
           <div className="mt-4 flex justify-center gap-4">
             <button
               type="button"
@@ -221,6 +245,7 @@ const PlanGenerator: React.FC = () => {
                   await createRunningPlan({
                     userId: user.id!,
                     planData,
+                    name: planName,
                   });
                   alert("Plan saved");
                 } catch (err) {

--- a/src/components/RecentRuns.tsx
+++ b/src/components/RecentRuns.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { listRuns } from "@lib/api/run";
+import { getRunName } from "@utils/running/getRunName";
 import type { Run } from "@maratypes/run";
 import RunModal from "@components/RunModal";
 
@@ -48,9 +49,7 @@ export default function RecentRuns() {
             className="border p-2 rounded cursor-pointer hover:bg-accent/10"
             onClick={() => setSelectedRun(run)}
           >
-            <span className="font-semibold">
-              {new Date(run.date).toLocaleDateString()}
-            </span>
+            <span className="font-semibold">{run.name || getRunName(run)}</span>
             {`: ${run.distance} ${run.distanceUnit}`}
           </li>
         ))}

--- a/src/components/RunForm.tsx
+++ b/src/components/RunForm.tsx
@@ -9,6 +9,7 @@ import isYupValidationError from "@lib/utils/validation/isYupValidationError";
 import { useSession } from "next-auth/react";
 import { useUserProfile } from "@hooks/useUserProfile";
 import { listShoes } from "@lib/api/shoe";
+import { getRunName } from "@utils/running/getRunName";
 
 import { Card, Button } from "@components/ui";
 import {
@@ -137,6 +138,7 @@ const RunForm: React.FC<RunFormProps> = ({ onSubmit }) => {
         distance: valid.distance,
         distanceUnit: valid.distanceUnit,
         trainingEnvironment: valid.trainingEnvironment || undefined,
+        name: getRunName({ date: new Date(valid.date), trainingEnvironment: valid.trainingEnvironment }),
         elevationGain: valid.elevationGain || undefined,
         elevationGainUnit: valid.elevationGainUnit || undefined,
         notes: valid.notes || undefined,

--- a/src/components/RunModal.tsx
+++ b/src/components/RunModal.tsx
@@ -2,6 +2,7 @@
 
 import { Run } from "@maratypes/run";
 import { Card } from "@components/ui";
+import { getRunName } from "@utils/running/getRunName";
 
 interface RunModalProps {
   run: Run;
@@ -32,7 +33,7 @@ export default function RunModal({ run, onClose }: RunModalProps) {
         </button>
 
         <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
-          {new Date(run.date).toLocaleDateString()}
+          {run.name || getRunName(run)}
         </h2>
         <div className="space-y-2 text-sm text-gray-800 dark:text-gray-200">
           <p>

--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -44,11 +44,7 @@ export default function TrainingPlansList() {
       {plans.map((plan) => (
         <li key={plan.id} className="border p-2 rounded">
           <Link href={`/plans/${plan.id ?? ""}`} className="block">
-            <span className="font-semibold">
-              {plan.createdAt
-                ? new Date(plan.createdAt).toLocaleDateString()
-                : "Unnamed Plan"}
-            </span>
+            <span className="font-semibold">{plan.name}</span>
             {plan.planData?.weeks && ` - ${plan.planData.weeks} weeks`}
           </Link>
         </li>

--- a/src/lib/api/run/index.ts
+++ b/src/lib/api/run/index.ts
@@ -9,6 +9,7 @@ const mapRun = (data: any): Run => ({
   distance: data.distance,
   distanceUnit: data.distanceUnit,
   trainingEnvironment: data.trainingEnvironment ?? undefined,
+  name: data.name ?? undefined,
   pace:
     data.pace && data.paceUnit
       ? { pace: data.pace, unit: data.paceUnit }

--- a/src/lib/utils/running/getRunName.ts
+++ b/src/lib/utils/running/getRunName.ts
@@ -1,0 +1,9 @@
+import type { Run } from "@maratypes/run";
+
+export const getRunName = (run: Pick<Run, 'date' | 'trainingEnvironment'>): string => {
+  const dt = new Date(run.date);
+  const datePart = dt.toLocaleDateString();
+  const timePart = dt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const env = run.trainingEnvironment ?? 'unspecified';
+  return `${datePart} ${timePart} - ${env}`;
+};

--- a/src/maratypes/run.ts
+++ b/src/maratypes/run.ts
@@ -7,6 +7,7 @@ export interface Run {
   distance: number;
   distanceUnit: "miles" | "kilometers";
   trainingEnvironment?: "outdoor" | "treadmill" | "indoor" | "mixed";
+  name?: string;
   pace?: Pace;
   elevationGain?: number;
   elevationGainUnit?: "miles" | "kilometers" | "meters" | "feet";

--- a/src/maratypes/runningPlan.ts
+++ b/src/maratypes/runningPlan.ts
@@ -6,6 +6,7 @@ import { Pace } from "./run";
 export interface RunningPlan {
   id?: string;
   userId: string;
+  name: string;
   planData: RunningPlanData; // Use the renamed type here.
   createdAt?: Date;
   updatedAt?: Date;


### PR DESCRIPTION
## Summary
- add plan and run `name` fields to schema
- auto-generate plan names sequentially and allow editing before save
- compute run names from date/time/environment
- display plan and run names in the UI
- include helper util `getRunName`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434841262883248d7f0f7c106dea63