### PR TITLE
Enable marking current week's runs done

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,6 +149,9 @@ model RunningPlan {
   name      String
   weeks     Int
   planData  Json
+  startDate DateTime?
+  endDate   DateTime?
+  active    Boolean   @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import RecentRuns from "@components/RecentRuns";
 import TrainingPlansList from "@components/TrainingPlansList";
+import WeeklyRuns from "@components/WeeklyRuns";
 
 export default function HomePage() {
   const { data: session, status } = useSession();
@@ -75,6 +76,13 @@ export default function HomePage() {
       <div className="max-w-4xl mx-auto">
         <section>
           <RecentRuns />
+        </section>
+      </div>
+
+      <h2 className="text-2xl font-semibold mb-4">This Week&apos;s Runs</h2>
+      <div className="max-w-4xl mx-auto">
+        <section>
+          <WeeklyRuns />
         </section>
       </div>
       

--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getRunningPlan } from "@lib/api/plan";
+import { assignDatesToPlan } from "@utils/running/planDates";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import RunningPlanDisplay from "@components/RunningPlanDisplay";
 
@@ -22,6 +23,12 @@ export default function PlanPage({ params }: PageProps) {
     const fetchPlan = async () => {
       try {
         const fetched: RunningPlan = await getRunningPlan(id);
+        if (fetched.planData) {
+          fetched.planData = assignDatesToPlan(fetched.planData, {
+            startDate: fetched.startDate?.toString(),
+            endDate: fetched.endDate?.toString(),
+          });
+        }
         if (session?.user && fetched.userId !== session.user.id) {
           router.push("/home");
           return;

--- a/src/components/PlanGenerator.tsx
+++ b/src/components/PlanGenerator.tsx
@@ -7,6 +7,7 @@ import RunningPlanDisplay from "./RunningPlanDisplay";
 import { generateRunningPlan } from "@utils/running/plans/baseRunningPlan";
 import { RunningPlanData } from "@maratypes/runningPlan";
 import { createRunningPlan, listRunningPlans } from "@lib/api/plan";
+import { assignDatesToPlan } from "@utils/running/planDates";
 
 const DEFAULT_WEEKS = 16;
 const DEFAULT_DISTANCE = 26.2;
@@ -32,6 +33,8 @@ const PlanGenerator: React.FC = () => {
   const [showJson, setShowJson] = useState<boolean>(false);
   const [editPlan, setEditPlan] = useState<boolean>(false);
   const [planName, setPlanName] = useState<string>("Training Plan 1");
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
 
   const [trainingLevel, setTrainingLevel] = useState<TrainingLevel>(
     TrainingLevel.Beginner
@@ -228,24 +231,66 @@ const PlanGenerator: React.FC = () => {
         <div className="mt-6">
           <h2 className="text-2xl font-bold text-center mb-4">Running Plan:</h2>
           <div className="mb-4">
-            <label className="block mb-1 font-semibold">Plan Name</label>
-            <input
-              type="text"
-              value={planName}
-              onChange={(e) => setPlanName(e.target.value)}
-              className="border p-2 rounded w-full"
-            />
-          </div>
+          <label className="block mb-1 font-semibold">Plan Name</label>
+          <input
+            type="text"
+            value={planName}
+            onChange={(e) => setPlanName(e.target.value)}
+            className="border p-2 rounded w-full"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1 font-semibold">Start Date</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="border p-2 rounded w-full"
+          />
+          {startDate && (
+            <button
+              type="button"
+              onClick={() => setStartDate("")}
+              className="mt-1 text-sm underline text-blue-600"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1 font-semibold">End Date</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="border p-2 rounded w-full"
+          />
+          {endDate && (
+            <button
+              type="button"
+              onClick={() => setEndDate("")}
+              className="mt-1 text-sm underline text-blue-600"
+            >
+              Clear
+            </button>
+          )}
+        </div>
           <div className="mt-4 flex justify-center gap-4">
             <button
               type="button"
               onClick={async () => {
                 if (!user) return;
                 try {
+                  const planWithDates = startDate || endDate
+                    ? assignDatesToPlan(planData, { startDate, endDate })
+                    : planData;
                   await createRunningPlan({
                     userId: user.id!,
-                    planData,
+                    planData: planWithDates,
                     name: planName,
+                    startDate: startDate ? new Date(startDate).toISOString() : undefined,
+                    endDate: endDate ? new Date(endDate).toISOString() : undefined,
+                    active: false,
                   });
                   alert("Plan saved");
                 } catch (err) {

--- a/src/components/RunningPlanDisplay.tsx
+++ b/src/components/RunningPlanDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { RunningPlanData, WeekPlan } from "@maratypes/runningPlan";
+import { DayOfWeek } from "@maratypes/basics";
 import { parsePace, formatPace } from "@utils/running/paces";
 
 interface RunningPlanDisplayProps {
@@ -55,6 +56,16 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  const days: DayOfWeek[] = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+
   return (
     <div className="border border-gray-300 rounded shadow-sm mb-4">
       <div
@@ -69,9 +80,13 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
       </div>
       {isOpen && (
         <div className="p-4 bg-gray-400 text-gray-800">
+          <p className="mb-2">Start: {weekPlan.startDate?.slice(0, 10)}</p>
           <ul className="space-y-3">
-            {weekPlan.runs.map((run, index) => (
-              <li key={index} className="border-t border-gray-300 pt-2 space-y-1">
+            {weekPlan.runs.map((run, index) => {
+              const past = run.date ? new Date(run.date) < new Date() : false;
+              const classes = past || run.done ? "text-gray-500 line-through" : "";
+              return (
+              <li key={index} className={`border-t border-gray-300 pt-2 space-y-1 ${classes}`}> 
                 <p>
                   <strong>Type:</strong>{" "}
                   {run.type.charAt(0).toUpperCase() + run.type.slice(1)}
@@ -111,6 +126,20 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                       />
                     </label>
                     <label className="block">
+                      <span className="mr-2">Day:</span>
+                      <select
+                        value={run.day || "Sunday"}
+                        onChange={(e) =>
+                          updateRun(weekIndex, index, "day", e.target.value as DayOfWeek)
+                        }
+                        className="border p-1 rounded text-black"
+                      >
+                        {days.map((d) => (
+                          <option key={d} value={d}>{d}</option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="block">
                       <span className="mr-2">Notes:</span>
                       <input
                         type="text"
@@ -121,6 +150,17 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                         className="border p-1 rounded text-black w-full"
                       />
                     </label>
+                    <label className="block">
+                      <input
+                        type="checkbox"
+                        checked={run.done || false}
+                        onChange={(e) =>
+                          updateRun(weekIndex, index, "done", e.target.checked)
+                        }
+                        className="mr-2"
+                      />
+                      Mark done
+                    </label>
                   </div>
                 ) : (
                   <>
@@ -130,15 +170,40 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                     <p>
                       <strong>Target Pace:</strong> {run.targetPace.pace} per {run.targetPace.unit}
                     </p>
+                    {run.day && (
+                      <p>
+                        <strong>Day:</strong> {run.day}
+                      </p>
+                    )}
+                    {run.date && (
+                      <p>
+                        <strong>Date:</strong> {run.date.slice(0, 10)}
+                      </p>
+                    )}
                     {run.notes && (
                       <p>
                         <strong>Notes:</strong> {run.notes}
                       </p>
                     )}
+                    {typeof run.done !== "undefined" && (
+                      <p>
+                        <input
+                          type="checkbox"
+                          checked={run.done}
+                          onChange={(e) =>
+                            updateRun(weekIndex, index, "done", e.target.checked)
+                          }
+                          className="mr-2"
+                          disabled={!editable}
+                        />
+                        <span>Done</span>
+                      </p>
+                    )}
                   </>
                 )}
               </li>
-            ))}
+              );
+            })}
           </ul>
         </div>
       )}

--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { listRunningPlans } from "@lib/api/plan";
+import { listRunningPlans, updateRunningPlan } from "@lib/api/plan";
 import type { RunningPlan } from "@maratypes/runningPlan";
 
 export default function TrainingPlansList() {
@@ -35,6 +35,23 @@ export default function TrainingPlansList() {
     fetchPlans();
   }, [session?.user?.id]);
 
+  const setActive = async (id: string) => {
+    try {
+      await Promise.all(
+        plans.map((p) =>
+          p.id
+            ? updateRunningPlan(p.id, { active: p.id === id })
+            : Promise.resolve()
+        )
+      );
+      setPlans((prev) =>
+        prev.map((p) => ({ ...p, active: p.id === id }))
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   if (loading) return <p className="text-gray-500">Loading plans...</p>;
   if (plans.length === 0)
     return <p className="text-gray-500">No plans saved.</p>;
@@ -46,7 +63,16 @@ export default function TrainingPlansList() {
           <Link href={`/plans/${plan.id ?? ""}`} className="block">
             <span className="font-semibold">{plan.name}</span>
             {plan.planData?.weeks && ` - ${plan.planData.weeks} weeks`}
+            {plan.active && <span className="ml-2 text-green-600">(active)</span>}
           </Link>
+          {!plan.active && (
+            <button
+              onClick={() => plan.id && setActive(plan.id)}
+              className="mt-1 text-sm underline text-blue-600"
+            >
+              Set Active
+            </button>
+          )}
         </li>
       ))}
     </ul>

--- a/src/components/WeeklyRuns.tsx
+++ b/src/components/WeeklyRuns.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { listRunningPlans, updateRunningPlan } from "@lib/api/plan";
+import { createRun } from "@lib/api/run";
+import type { RunningPlan } from "@maratypes/runningPlan";
+import { assignDatesToPlan } from "@utils/running/planDates";
+import { calculateDurationFromPace } from "@utils/running/calculateDuration";
+
+export default function WeeklyRuns() {
+  const { data: session } = useSession();
+  const [plan, setPlan] = useState<RunningPlan | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPlan = async () => {
+      try {
+        const plans: RunningPlan[] = await listRunningPlans();
+        const active = plans.find(
+          (p) => p.active && p.userId === session?.user?.id
+        );
+        if (active && active.planData) {
+          active.planData = assignDatesToPlan(active.planData, {
+            startDate: active.startDate?.toString(),
+            endDate: active.endDate?.toString(),
+          });
+          setPlan(active);
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPlan();
+  }, [session?.user?.id]);
+
+  if (loading) return <p className="text-gray-500">Loading...</p>;
+  if (!plan) return <p className="text-gray-500">No active plan.</p>;
+
+  let weekIndex: number;
+  if (plan.planData.startDate) {
+    const start = new Date(plan.planData.startDate);
+    const now = new Date();
+    weekIndex = Math.floor(
+      (Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()) -
+        Date.UTC(start.getFullYear(), start.getMonth(), start.getDate())) /
+        (7 * 24 * 60 * 60 * 1000)
+    );
+  } else {
+    weekIndex = plan.planData.schedule.findIndex((w) => !w.done);
+  }
+  if (weekIndex < 0 || !plan.planData.schedule[weekIndex]) {
+    return <p className="text-gray-500">Plan completed!</p>;
+  }
+  const week = plan.planData.schedule[weekIndex];
+
+  const toggleDone = async (idx: number) => {
+    if (!plan || !plan.id) return;
+    const updated = { ...plan };
+    const run = updated.planData.schedule[weekIndex].runs[idx];
+    run.done = !run.done;
+    updated.planData.schedule[weekIndex].done = updated.planData.schedule[
+      weekIndex
+    ].runs.every((r) => r.done);
+    try {
+      await updateRunningPlan(plan.id, { planData: updated.planData });
+      if (run.done) {
+        await createRun({
+          date: run.date ?? new Date().toISOString(),
+          duration: calculateDurationFromPace(run.mileage, run.targetPace.pace),
+          distance: run.mileage,
+          distanceUnit: run.unit,
+          userId: plan.userId,
+          name: `${run.type} run`,
+        });
+      }
+      setPlan(updated);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xl font-semibold">Runs this week</h3>
+      <ul className="space-y-1">
+        {week.runs.map((r, i) => (
+          <li
+            key={i}
+            className={r.done ? "text-gray-500 line-through" : undefined}
+          >
+            <label className="space-x-2">
+              <input
+                type="checkbox"
+                checked={r.done || false}
+                onChange={() => toggleDone(i)}
+              />
+              <span>
+                {r.date?.slice(0, 10)} - {r.type} {r.mileage} {r.unit}
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/utils/__tests__/calculateDuration.test.ts
+++ b/src/lib/utils/__tests__/calculateDuration.test.ts
@@ -1,0 +1,8 @@
+import { calculateDurationFromPace } from "../running/calculateDuration";
+
+describe("calculateDurationFromPace", () => {
+  it("computes duration from pace and distance", () => {
+    expect(calculateDurationFromPace(5, "06:00")).toBe("00:30:00");
+    expect(calculateDurationFromPace(10, "06:00")).toBe("01:00:00");
+  });
+});

--- a/src/lib/utils/__tests__/planDates.test.ts
+++ b/src/lib/utils/__tests__/planDates.test.ts
@@ -1,0 +1,49 @@
+import { assignDatesToPlan, removeDatesFromPlan } from "../running/planDates";
+import { RunningPlanData } from "@maratypes/runningPlan";
+
+describe("assignDatesToPlan", () => {
+  it("assigns week and run dates from start date", () => {
+    const data: RunningPlanData = {
+      weeks: 2,
+      schedule: [
+        { weekNumber: 1, weeklyMileage: 10, unit: "miles", runs: [{ type: "easy", unit: "miles", targetPace: { unit: "miles", pace: "10:00" }, mileage: 5, day: "Monday" }] },
+        { weekNumber: 2, weeklyMileage: 10, unit: "miles", runs: [{ type: "easy", unit: "miles", targetPace: { unit: "miles", pace: "10:00" }, mileage: 5, day: "Monday" }] },
+      ],
+    };
+    const result = assignDatesToPlan(data, { startDate: "2024-06-30" });
+    expect(result.schedule[0].startDate).toBe("2024-06-30T00:00:00.000Z");
+    expect(result.schedule[0].runs[0].date).toBe("2024-07-01T00:00:00.000Z");
+  });
+
+  it("clears all dates from the plan", () => {
+    const data: RunningPlanData = {
+      weeks: 1,
+      schedule: [
+        {
+          weekNumber: 1,
+          weeklyMileage: 10,
+          unit: "miles",
+          runs: [
+            {
+              type: "easy",
+              unit: "miles",
+              targetPace: { unit: "miles", pace: "10:00" },
+              mileage: 5,
+              day: "Monday",
+              date: "2024-07-01T00:00:00.000Z",
+              done: false,
+            },
+          ],
+          startDate: "2024-06-30T00:00:00.000Z",
+          done: false,
+        },
+      ],
+      startDate: "2024-06-30T00:00:00.000Z",
+      endDate: "2024-06-30T00:00:00.000Z",
+    };
+    const result = removeDatesFromPlan(data);
+    expect(result.startDate).toBeUndefined();
+    expect(result.schedule[0].startDate).toBeUndefined();
+    expect(result.schedule[0].runs[0].date).toBeUndefined();
+  });
+});

--- a/src/lib/utils/running/calculateDuration.ts
+++ b/src/lib/utils/running/calculateDuration.ts
@@ -1,0 +1,10 @@
+export function calculateDurationFromPace(distance: number, pace: string): string {
+  const [min, sec] = pace.split(":").map(Number);
+  const total = (min * 60 + sec) * distance;
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = Math.round(total % 60);
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/src/lib/utils/running/planDates.ts
+++ b/src/lib/utils/running/planDates.ts
@@ -1,0 +1,77 @@
+export type { DayOfWeek } from "@maratypes/basics";
+import { DayOfWeek } from "@maratypes/basics";
+import type { RunningPlanData } from "@maratypes/runningPlan";
+
+function startOfWeekSunday(date: Date): Date {
+  const d = new Date(date);
+  const diff = d.getDay();
+  d.setDate(d.getDate() - diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function addWeeks(date: Date, weeks: number): Date {
+  return addDays(date, weeks * 7);
+}
+
+const dayIndexMap: Record<DayOfWeek, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+export function dayIndex(day: DayOfWeek): number {
+  return dayIndexMap[day];
+}
+
+export function assignDatesToPlan(
+  plan: RunningPlanData,
+  opts: { startDate?: string; endDate?: string }
+): RunningPlanData {
+  const { startDate, endDate } = opts;
+  if (!startDate && !endDate) return plan;
+  const baseStart = startDate
+    ? startOfWeekSunday(new Date(startDate))
+    : addWeeks(startOfWeekSunday(new Date(endDate!)), -(plan.weeks - 1));
+  const schedule = plan.schedule.map((week, wi) => {
+    const weekStart = addWeeks(baseStart, wi);
+    const runs = week.runs.map((r) => {
+      const idx = r.day ? dayIndex(r.day) : 0;
+      const date = addDays(weekStart, idx);
+      return { ...r, date: date.toISOString() };
+    });
+    const done = runs.every((r) => r.done);
+    return { ...week, startDate: weekStart.toISOString(), runs, done };
+  });
+  const end = addWeeks(baseStart, plan.weeks - 1);
+  return {
+    ...plan,
+    schedule,
+    startDate: baseStart.toISOString(),
+    endDate: end.toISOString(),
+  };
+}
+
+export function removeDatesFromPlan(plan: RunningPlanData): RunningPlanData {
+  const schedule = plan.schedule.map((week) => ({
+    ...week,
+    startDate: undefined,
+    runs: week.runs.map((r) => ({ ...r, date: undefined })),
+  }));
+  return {
+    ...plan,
+    schedule,
+    startDate: undefined,
+    endDate: undefined,
+  };
+}

--- a/src/maratypes/runningPlan.ts
+++ b/src/maratypes/runningPlan.ts
@@ -1,7 +1,7 @@
 // @maratypes/runningPlan.ts
 
 import { Pace } from "./run";
-import { DistanceUnit } from "@maratypes/basics";
+import { DistanceUnit, DayOfWeek } from "@maratypes/basics";
 
 
 // main type
@@ -10,6 +10,9 @@ export interface RunningPlan {
   userId: string;
   name: string;
   planData: RunningPlanData; // Use the renamed type here.
+  startDate?: Date;
+  endDate?: Date;
+  active?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -20,6 +23,9 @@ export interface PlannedRun {
   targetPace: Pace;
   mileage: number;
   notes?: string;
+  day?: DayOfWeek;
+  date?: string;
+  done?: boolean;
 }
 
 export interface WeekPlan {
@@ -28,10 +34,14 @@ export interface WeekPlan {
   unit: DistanceUnit;
   runs: PlannedRun[];
   notes?: string;
+  startDate?: string;
+  done?: boolean;
 }
 
 export interface RunningPlanData {
   weeks: number;
   schedule: WeekPlan[];
+  startDate?: string;
+  endDate?: string;
   notes?: string;
 }


### PR DESCRIPTION
## Summary
- add helper to strip or apply plan dates
- support selecting and clearing start or end dates when creating a plan
- compute current week based on dates or completion
- add tests for date helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68445f05f490832484f7b4f605b75d8c