### PR TITLE
Handle timezone correctly and persist new plan fields

### DIFF
--- a/src/app/api/running-plans/route.ts
+++ b/src/app/api/running-plans/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { userId, weeks, planData, name } = body;
+    const { userId, weeks, planData, name, startDate, endDate, active } = body;
 
     if (!userId) {
       return NextResponse.json({ error: "User ID is required" }, { status: 400 });
@@ -39,6 +39,9 @@ export async function POST(request: NextRequest) {
         weeks: Number(derivedWeeks),
         planData,
         name: name || defaultName,
+        startDate: startDate ? new Date(startDate) : undefined,
+        endDate: endDate ? new Date(endDate) : undefined,
+        active: active ?? false,
       },
     });
 

--- a/src/components/WeeklyRuns.tsx
+++ b/src/components/WeeklyRuns.tsx
@@ -59,13 +59,14 @@ export default function WeeklyRuns() {
     if (!plan || !plan.id) return;
     const updated = { ...plan };
     const run = updated.planData.schedule[weekIndex].runs[idx];
+    const wasDone = run.done ?? false;
     run.done = !run.done;
     updated.planData.schedule[weekIndex].done = updated.planData.schedule[
       weekIndex
     ].runs.every((r) => r.done);
     try {
       await updateRunningPlan(plan.id, { planData: updated.planData });
-      if (run.done) {
+      if (!wasDone && run.done) {
         await createRun({
           date: run.date ?? new Date().toISOString(),
           duration: calculateDurationFromPace(run.mileage, run.targetPace.pace),

--- a/src/lib/utils/running/planDates.ts
+++ b/src/lib/utils/running/planDates.ts
@@ -2,17 +2,23 @@ export type { DayOfWeek } from "@maratypes/basics";
 import { DayOfWeek } from "@maratypes/basics";
 import type { RunningPlanData } from "@maratypes/runningPlan";
 
+function parseDateUTC(date: string | Date): Date {
+  if (date instanceof Date) return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  // treat plain dates as UTC to avoid timezone offsets
+  return new Date(date.includes("T") ? date : `${date}T00:00:00Z`);
+}
+
 function startOfWeekSunday(date: Date): Date {
-  const d = new Date(date);
-  const diff = d.getDay();
-  d.setDate(d.getDate() - diff);
-  d.setHours(0, 0, 0, 0);
+  const d = parseDateUTC(date);
+  const diff = d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() - diff);
+  d.setUTCHours(0, 0, 0, 0);
   return d;
 }
 
 function addDays(date: Date, days: number): Date {
-  const d = new Date(date);
-  d.setDate(d.getDate() + days);
+  const d = parseDateUTC(date);
+  d.setUTCDate(d.getUTCDate() + days);
   return d;
 }
 
@@ -41,8 +47,8 @@ export function assignDatesToPlan(
   const { startDate, endDate } = opts;
   if (!startDate && !endDate) return plan;
   const baseStart = startDate
-    ? startOfWeekSunday(new Date(startDate))
-    : addWeeks(startOfWeekSunday(new Date(endDate!)), -(plan.weeks - 1));
+    ? startOfWeekSunday(parseDateUTC(startDate))
+    : addWeeks(startOfWeekSunday(parseDateUTC(endDate!)), -(plan.weeks - 1));
   const schedule = plan.schedule.map((week, wi) => {
     const weekStart = addWeeks(baseStart, wi);
     const runs = week.runs.map((r) => {


### PR DESCRIPTION
## Summary
- keep date assignments timezone-neutral
- save start/end dates and active flag when creating running plans
- avoid duplicate run records when toggling completion

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844b90477f4832483ab0a7fc99bee34