### PR TITLE
Enhance training plan UX

### DIFF
--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -54,7 +54,7 @@ export default function PlanPage({ params }: PageProps) {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">{plan.name}</h1>
-      <RunningPlanDisplay planData={plan.planData} />
+      <RunningPlanDisplay planData={plan.planData} planName={plan.name} />
     </div>
   );
 }

--- a/src/components/PlanGenerator.tsx
+++ b/src/components/PlanGenerator.tsx
@@ -315,9 +315,9 @@ const PlanGenerator: React.FC = () => {
 
           <RunningPlanDisplay
             planData={planData}
+            planName={planName}
             editable={editPlan}
             onPlanChange={setPlanData}
-            // title=""
           />
           <div className="mt-4">
             <label className="flex items-center space-x-2">

--- a/src/components/RunningPlanDisplay.tsx
+++ b/src/components/RunningPlanDisplay.tsx
@@ -5,12 +5,14 @@ import { parsePace, formatPace } from "@utils/running/paces";
 
 interface RunningPlanDisplayProps {
   planData: RunningPlanData;
+  planName?: string;
   editable?: boolean;
   onPlanChange?: (plan: RunningPlanData) => void;
 }
 
 const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
   planData,
+  planName,
   editable = false,
   onPlanChange,
 }) => {
@@ -27,7 +29,9 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
   };
   return (
     <div className="container p-4">
-      <h2 className="text-2xl font-bold text-center mb-4">Your Running Plan</h2>
+      <h2 className="text-2xl font-bold text-center mb-4">
+        {planName || "Your Running Plan"}
+      </h2>
       {planData.schedule.map((weekPlan, wi) => (
         <CollapsibleWeek
           key={weekPlan.weekNumber}

--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { listRunningPlans, updateRunningPlan } from "@lib/api/plan";
 import type { RunningPlan } from "@maratypes/runningPlan";
+import { Card, Button } from "@components/ui";
 
 export default function TrainingPlansList() {
   const { data: session } = useSession();
@@ -57,24 +58,34 @@ export default function TrainingPlansList() {
     return <p className="text-gray-500">No plans saved.</p>;
 
   return (
-    <ul className="space-y-2">
+    <div className="space-y-2">
       {plans.map((plan) => (
-        <li key={plan.id} className="border p-2 rounded">
-          <Link href={`/plans/${plan.id ?? ""}`} className="block">
-            <span className="font-semibold">{plan.name}</span>
-            {plan.planData?.weeks && ` - ${plan.planData.weeks} weeks`}
-            {plan.active && <span className="ml-2 text-green-600">(active)</span>}
-          </Link>
-          {!plan.active && (
-            <button
-              onClick={() => plan.id && setActive(plan.id)}
-              className="mt-1 text-sm underline text-blue-600"
-            >
+        <Card key={plan.id} className="flex justify-between items-start">
+          <div>
+            <Link href={`/plans/${plan.id ?? ""}`} className="font-semibold underline">
+              {plan.name}
+            </Link>
+            <div className="text-sm">
+              {plan.planData?.weeks && <span>{plan.planData.weeks} weeks</span>}
+              {plan.startDate && (
+                <span className="ml-2">
+                  {new Date(plan.startDate).toLocaleDateString()} -
+                  {" "}
+                  {plan.endDate ? new Date(plan.endDate).toLocaleDateString() : ""}
+                </span>
+              )}
+              {plan.active && (
+                <span className="ml-2 text-green-600 font-medium">active</span>
+              )}
+            </div>
+          </div>
+          {!plan.active && plan.id && (
+            <Button onClick={() => setActive(plan.id)} className="text-sm px-2 py-1">
               Set Active
-            </button>
+            </Button>
           )}
-        </li>
+        </Card>
       ))}
-    </ul>
+    </div>
   );
 }

--- a/src/components/WeeklyRuns.tsx
+++ b/src/components/WeeklyRuns.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { listRunningPlans, updateRunningPlan } from "@lib/api/plan";
 import { createRun } from "@lib/api/run";
+import { Card } from "@components/ui";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import { assignDatesToPlan } from "@utils/running/planDates";
 import { calculateDurationFromPace } from "@utils/running/calculateDuration";
@@ -73,7 +74,7 @@ export default function WeeklyRuns() {
           distance: run.mileage,
           distanceUnit: run.unit,
           userId: plan.userId,
-          name: `${run.type} run`,
+          name: `${plan.name} - Week ${weekIndex + 1} - ${run.type} ${run.mileage} ${run.unit}`,
         });
       }
       setPlan(updated);
@@ -83,27 +84,36 @@ export default function WeeklyRuns() {
   };
 
   return (
-    <div className="space-y-2">
-      <h3 className="text-xl font-semibold">Runs this week</h3>
-      <ul className="space-y-1">
-        {week.runs.map((r, i) => (
-          <li
-            key={i}
-            className={r.done ? "text-gray-500 line-through" : undefined}
-          >
-            <label className="space-x-2">
-              <input
-                type="checkbox"
-                checked={r.done || false}
-                onChange={() => toggleDone(i)}
-              />
-              <span>
-                {r.date?.slice(0, 10)} - {r.type} {r.mileage} {r.unit}
-              </span>
-            </label>
-          </li>
-        ))}
-      </ul>
+    <div className="space-y-4">
+      <h3 className="text-xl font-semibold">
+        {plan.name} - Week {week.weekNumber}
+      </h3>
+      <div className="space-y-2">
+        {week.runs.map((r, i) => {
+          const classes = r.done ? "text-gray-500 line-through" : undefined;
+          return (
+            <Card key={i} className={`flex items-center justify-between ${classes}`}>
+              <div>
+                <p className="font-semibold">
+                  {r.date?.slice(0, 10)} - {r.type}
+                </p>
+                <p>
+                  {r.mileage} {r.unit} @ {r.targetPace.pace}
+                </p>
+                {r.notes && <p className="text-sm">{r.notes}</p>}
+              </div>
+              <label className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  checked={r.done || false}
+                  onChange={() => toggleDone(i)}
+                />
+                <span>{r.done ? "Completed" : "Mark done"}</span>
+              </label>
+            </Card>
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- prefix run names created from training plan with plan name and details
- show plan name in running plan display
- style weekly runs with cards and allow toggling completion
- improve training plan list layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844bbecb9448324950eed78c2145d8a