### PR TITLE
Improve training plan generator

### DIFF
--- a/src/lib/utils/__tests__/distancePlans.test.ts
+++ b/src/lib/utils/__tests__/distancePlans.test.ts
@@ -49,4 +49,37 @@ describe("distance-specific plan generators", () => {
     });
     expect(plan.schedule.length).toBe(16);
   });
+
+  it("easy run pace is slower than race pace and distance not over race", () => {
+    const plan = generateClassicMarathonPlan({
+      distanceUnit: "miles",
+      trainingLevel: TrainingLevel.Beginner,
+      vo2max: 40,
+      startingWeeklyMileage: 200,
+    });
+    const firstWeek = plan.schedule[0];
+    const easyRun = firstWeek.runs.find((r) => r.type === "easy")!;
+    const racePace = firstWeek.runs.find((r) => r.type === "long")!.targetPace
+      .pace;
+    const parse = (s: string) => {
+      const [m, s2] = s.split(":");
+      return parseInt(m) * 60 + parseInt(s2);
+    };
+    expect(easyRun.mileage).toBeLessThanOrEqual(26.2);
+    expect(parse(easyRun.targetPace.pace)).toBeGreaterThan(parse(racePace));
+  });
+
+  it("weekly mileage peaks before taper", () => {
+    const plan = generateClassicMarathonPlan({
+      distanceUnit: "miles",
+      trainingLevel: TrainingLevel.Beginner,
+      vo2max: 40,
+      startingWeeklyMileage: 20,
+    });
+    const mileages = plan.schedule.map((w) => w.weeklyMileage);
+    const peak = Math.max(...mileages.slice(0, -1));
+    const peakIndex = mileages.indexOf(peak);
+    expect(peakIndex).toBe(12); // week 13 (0-based index 12)
+    expect(mileages[13]).toBeLessThan(peak);
+  });
 });


### PR DESCRIPTION
## Summary
- tweak mileage progression to grow linearly up to the peak week
- clamp easy run mileage and pace relative to race goal
- add tests for new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a6902058832489fb6bbfa078ce77