### PR TITLE
Improve training plan date inference

### DIFF
--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -48,6 +48,9 @@ export default function TrainingPlansList() {
       setPlans((prev) =>
         prev.map((p) => ({ ...p, active: p.id === id }))
       );
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("activePlanChanged"));
+      }
     } catch (err) {
       console.error(err);
     }

--- a/src/components/WeeklyRuns.tsx
+++ b/src/components/WeeklyRuns.tsx
@@ -12,6 +12,13 @@ export default function WeeklyRuns() {
   const { data: session } = useSession();
   const [plan, setPlan] = useState<RunningPlan | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refresh, setRefresh] = useState(0);
+
+  useEffect(() => {
+    const handle = () => setRefresh((r) => r + 1);
+    window.addEventListener("activePlanChanged", handle);
+    return () => window.removeEventListener("activePlanChanged", handle);
+  }, []);
 
   useEffect(() => {
     const fetchPlan = async () => {
@@ -34,7 +41,7 @@ export default function WeeklyRuns() {
       }
     };
     fetchPlan();
-  }, [session?.user?.id]);
+  }, [session?.user?.id, refresh]);
 
   if (loading) return <p className="text-gray-500">Loading...</p>;
   if (!plan) return <p className="text-gray-500">No active plan.</p>;


### PR DESCRIPTION
## Summary
- infer start/end dates on the server when creating or updating a training plan
- default new plans to start next Sunday if no dates provided
- dispatch an event when setting a plan active
- refresh WeeklyRuns component when the active plan changes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460069310883249b21faad4ba377e0