### PR TITLE
Improve VO2 update and run ordering

### DIFF
--- a/src/app/api/runs/[id]/route.ts
+++ b/src/app/api/runs/[id]/route.ts
@@ -47,7 +47,13 @@ export async function PUT(
           : updatedRun.distance * 1000;
       const seconds = parseDuration(updatedRun.duration);
       const vo2 = Math.round(calculateVO2MaxJackDaniels(meters, seconds));
-      await prisma.user.update({ where: { id: updatedRun.userId }, data: { VO2Max: vo2 } });
+      const user = await prisma.user.findUnique({
+        where: { id: updatedRun.userId },
+        select: { VO2Max: true },
+      });
+      if (user && (user.VO2Max === null || vo2 > user.VO2Max)) {
+        await prisma.user.update({ where: { id: updatedRun.userId }, data: { VO2Max: vo2 } });
+      }
     } catch (err) {
       console.error("Failed to update VO2Max", err);
     }

--- a/src/components/WeeklyRuns.tsx
+++ b/src/components/WeeklyRuns.tsx
@@ -109,7 +109,7 @@ export default function WeeklyRuns() {
       await updateRunningPlan(plan.id, { planData: updated.planData });
       if (!wasDone && run.done) {
         await createRun({
-          date: run.date ?? new Date().toISOString(),
+          date: new Date().toISOString(),
           duration: calculateDurationFromPace(run.mileage, run.targetPace.pace),
           distance: run.mileage,
           distanceUnit: run.unit,


### PR DESCRIPTION
## Summary
- keep VO2 max updates monotonic when saving runs
- record completed training runs using the current date

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68460349a2248324823b6f9778922a3b