### PR TITLE
Add avatar support

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ export default function SignupPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState("");
   const [error, setError] = useState("");
   const router = useRouter();
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -21,7 +22,7 @@ export default function SignupPage() {
     }
 
     try {
-      const createUserRes = await createUserProfile({ name, email });
+      const createUserRes = await createUserProfile({ name, email, avatarUrl });
 
       if (createUserRes?.status === 201 || createUserRes?.status === 200) {
         // Now sign in the new user
@@ -64,6 +65,28 @@ export default function SignupPage() {
               className="w-full px-3 py-2 border border-gray-300 rounded bg-gray-200 focus:ring-2 focus:ring-primary"
             />
           </div>
+          <div>
+            <label htmlFor="avatar" className="block mb-1">
+              Profile Picture URL
+            </label>
+            <input
+              type="url"
+              id="avatar"
+              value={avatarUrl}
+              onChange={(e) => setAvatarUrl(e.target.value)}
+              placeholder="https://example.com/avatar.png"
+              className="w-full px-3 py-2 border border-gray-300 rounded bg-gray-200 focus:ring-2 focus:ring-primary"
+            />
+          </div>
+          {avatarUrl && (
+            <div className="flex justify-center">
+              <img
+                src={avatarUrl}
+                alt="Avatar preview"
+                className="w-20 h-20 rounded-full object-cover"
+              />
+            </div>
+          )}
           <div>
             <label htmlFor="email" className="block mb-1">
               Email

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -27,10 +27,20 @@ export const authOptions: NextAuthOptions = {
       if (session.user && token.sub) {
         session.user.id = token.sub;
       }
+      if (session.user && (token as JWT & { avatarUrl?: string }).avatarUrl) {
+        session.user.image = (
+          token as JWT & { avatarUrl?: string }
+        ).avatarUrl as string;
+      }
       return session;
     },
     async jwt({ token, user }: { token: JWT; user?: User }) {
-      if (user) token.id = user.id;
+      if (user) {
+        token.id = user.id;
+        (token as JWT & { avatarUrl?: string }).avatarUrl = (
+          user as User & { avatarUrl?: string }
+        ).avatarUrl;
+      }
       return token;
     },
   },

--- a/src/components/UserProfileForm/BasicInfoSection.tsx
+++ b/src/components/UserProfileForm/BasicInfoSection.tsx
@@ -30,6 +30,20 @@ export default function BasicInfoSection({
       <h3 className={styles.title}>Basic Information</h3>
       {isEditing ? (
         <div>
+          <div className="flex items-center space-x-4 mb-4">
+            <img
+              src={formData.avatarUrl || "/Default_pfp.svg"}
+              alt="Avatar preview"
+              className="w-20 h-20 rounded-full object-cover"
+            />
+            <TextField
+              label="Avatar URL"
+              name="avatarUrl"
+              value={formData.avatarUrl || ""}
+              editing={isEditing}
+              onChange={handleFieldChange}
+            />
+          </div>
           <TextField
             label="Name"
             name="name"
@@ -86,6 +100,13 @@ export default function BasicInfoSection({
         </div>
       ) : (
         <dl className={styles.list}>
+          <div className="md:col-span-2 flex items-center mb-4">
+            <img
+              src={formData.avatarUrl || "/Default_pfp.svg"}
+              alt="Avatar"
+              className="w-20 h-20 rounded-full object-cover"
+            />
+          </div>
           <div>
             <dt className={styles.label}>Name</dt>
             <dd className={styles.value}>{formData.name || "N/A"}</dd>

--- a/src/maratypes/next-auth.d.ts
+++ b/src/maratypes/next-auth.d.ts
@@ -13,5 +13,13 @@ declare module "next-auth" {
   }
   interface User {
     id: string;
+    avatarUrl?: string | null;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id?: string;
+    avatarUrl?: string | null;
   }
 }


### PR DESCRIPTION
## Summary
- prompt for avatar URL on signup and show preview
- store avatar URL in JWT/session for navbar usage
- edit avatar in profile form
- extend NextAuth types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684621a944188324b07244ac45e8bfe0