### PR TITLE
Fix avatar not refreshing in Navbar

### DIFF
--- a/src/app/(auth)/signup/profile/page.tsx
+++ b/src/app/(auth)/signup/profile/page.tsx
@@ -8,7 +8,7 @@ import { UserProfile } from "@maratypes/user";
 import { useEffect } from "react";
 
 export default function OnboardingProfile() {
-  const { data: session, status } = useSession();
+  const { data: session, status, update } = useSession();
   const router = useRouter();
 
   // If not authenticated, redirect to signup
@@ -36,7 +36,8 @@ export default function OnboardingProfile() {
 
   const onSave = async (updated: UserProfile) => {
     await updateUserProfile(initialUser.id, updated);
-    // Optionally update client state here
+    // Refresh session so avatar updates in navbar
+    await update({ user: { image: updated.avatarUrl ?? null } });
     router.push("/home");
   };
 

--- a/src/app/(auth)/userProfile/page.tsx
+++ b/src/app/(auth)/userProfile/page.tsx
@@ -8,7 +8,7 @@ import { UserProfile } from "@maratypes/user";
 import { getUserProfile, updateUserProfile } from "@lib/api/user/user";
 
 export default function UserProfilePage() {
-  const { data: session, status } = useSession();
+  const { data: session, status, update } = useSession();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -41,6 +41,7 @@ export default function UserProfilePage() {
       setLoading(true);
       await updateUserProfile(updated.id, updated);
       setProfile(updated);
+      await update({ user: { image: updated.avatarUrl ?? null } });
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 2000);
     } catch {


### PR DESCRIPTION
## Summary
- refresh session avatar when user profile is saved
- update signup profile flow to refresh session
- refresh session on user profile updates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68463231620483249773fd21fdd902f9