### PR TITLE
Fix avatar refresh

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -32,7 +32,6 @@ export const authOptions: NextAuthOptions = {
           token as JWT & { avatarUrl?: string }
         ).avatarUrl as string;
         session.user.avatarUrl = avatar;
-        session.user.image = avatar;
       }
       return session;
     },

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -76,7 +76,7 @@ export default function Navbar() {
                   className="focus:outline-none bg-transparent p-0 hover:bg-transparent focus:ring-0"
                 >
                   <Image
-                    src={session.user.image ?? session.user.avatarUrl ?? "/Default_pfp.svg"}
+                    src={session.user.avatarUrl ?? "/Default_pfp.svg"}
                     alt="avatar"
                     width={32}
                     height={32}
@@ -131,7 +131,7 @@ export default function Navbar() {
                 <div className="w-8 h-8 rounded-full overflow-hidden">
                   {" "}
                   <Image
-                    src={session.user.image ?? session.user.avatarUrl ?? "/Default_pfp.svg"}
+                    src={session.user.avatarUrl ?? "/Default_pfp.svg"}
                     alt="avatar"
                     width={24}
                     height={24}


### PR DESCRIPTION
## Summary
- update navbar to rely solely on `session.user.avatarUrl`
- drop unused `session.user.image` handling in NextAuth callbacks

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684790c592448324b9259d04f72d456f