### PR TITLE
Add plan deletion and editing improvements

### DIFF
--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getRunningPlan } from "@lib/api/plan";
+import { getRunningPlan, updateRunningPlan } from "@lib/api/plan";
 import { assignDatesToPlan } from "@utils/running/planDates";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import RunningPlanDisplay from "@components/RunningPlanDisplay";
+import { Button } from "@components/ui";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -16,6 +17,8 @@ export default function PlanPage({ params }: PageProps) {
   const { id } = use(params);
   const { data: session, status } = useSession();
   const [plan, setPlan] = useState<RunningPlan | null>(null);
+  const [planData, setPlanData] = useState<RunningPlan["planData"] | null>(null);
+  const [editing, setEditing] = useState(false);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
@@ -34,6 +37,7 @@ export default function PlanPage({ params }: PageProps) {
           return;
         }
         setPlan(fetched);
+        setPlanData(fetched.planData);
       } catch (err) {
         console.error(err);
       } finally {
@@ -54,7 +58,36 @@ export default function PlanPage({ params }: PageProps) {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">{plan.name}</h1>
-      <RunningPlanDisplay planData={plan.planData} planName={plan.name} />
+      <div className="mb-4 space-x-2">
+        <Button onClick={() => setEditing((e) => !e)}>
+          {editing ? "Cancel" : "Edit"}
+        </Button>
+        {editing && (
+          <Button
+            onClick={async () => {
+              if (!plan.id || !planData) return;
+              try {
+                await updateRunningPlan(plan.id, { planData });
+                setEditing(false);
+                setPlan((p) => (p ? { ...p, planData } : p));
+              } catch (err) {
+                console.error(err);
+              }
+            }}
+            className="bg-green-600 ml-2"
+          >
+            Save
+          </Button>
+        )}
+      </div>
+      {planData && (
+        <RunningPlanDisplay
+          planData={planData}
+          planName={plan.name}
+          editable={editing}
+          onPlanChange={setPlanData}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/RunningPlanDisplay.tsx
+++ b/src/components/RunningPlanDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import { RunningPlanData, WeekPlan } from "@maratypes/runningPlan";
+import { RunningPlanData, WeekPlan, PlannedRun } from "@maratypes/runningPlan";
 import { DayOfWeek } from "@maratypes/basics";
+import { setDayForRunType } from "@utils/running/setRunDay";
 import { parsePace, formatPace } from "@utils/running/paces";
 
 interface RunningPlanDisplayProps {
@@ -32,6 +33,12 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
       <h2 className="text-2xl font-bold text-center mb-4">
         {planName || "Your Running Plan"}
       </h2>
+      {editable && (
+        <BulkDaySetter
+          planData={planData}
+          onPlanChange={onPlanChange}
+        />
+      )}
       {planData.schedule.map((weekPlan, wi) => (
         <CollapsibleWeek
           key={weekPlan.weekNumber}
@@ -271,6 +278,68 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
           </ul>
         </div>
       )}
+    </div>
+  );
+};
+
+interface BulkDaySetterProps {
+  planData: RunningPlanData;
+  onPlanChange?: (plan: RunningPlanData) => void;
+}
+
+const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange }) => {
+  const days: DayOfWeek[] = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const runTypes: PlannedRun["type"][] = ["easy", "tempo", "interval", "long", "marathon"];
+  const [type, setType] = useState<PlannedRun["type"]>("easy");
+  const [day, setDay] = useState<DayOfWeek>("Monday");
+
+  const apply = () => {
+    if (!onPlanChange) return;
+    const updated = setDayForRunType(planData, type, day);
+    onPlanChange(updated);
+  };
+
+  return (
+    <div className="mb-4 flex items-center gap-2 justify-center">
+      <span>Set all</span>
+      <select
+        value={type}
+        onChange={(e) => setType(e.target.value as PlannedRun["type"])}
+        className="border p-1 rounded text-black"
+      >
+        {runTypes.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <span>runs to</span>
+      <select
+        value={day}
+        onChange={(e) => setDay(e.target.value as DayOfWeek)}
+        className="border p-1 rounded text-black"
+      >
+        {days.map((d) => (
+          <option key={d} value={d}>
+            {d}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={apply}
+        className="bg-blue-500 text-white px-3 py-1 rounded"
+      >
+        Apply
+      </button>
     </div>
   );
 };

--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { listRunningPlans, updateRunningPlan } from "@lib/api/plan";
+import { listRunningPlans, updateRunningPlan, deleteRunningPlan } from "@lib/api/plan";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import { Card, Button } from "@components/ui";
 
@@ -56,6 +56,16 @@ export default function TrainingPlansList() {
     }
   };
 
+  const deletePlan = async (id: string) => {
+    if (!confirm("Delete this plan?")) return;
+    try {
+      await deleteRunningPlan(id);
+      setPlans((prev) => prev.filter((p) => p.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   if (loading) return <p className="text-gray-500">Loading plans...</p>;
   if (plans.length === 0)
     return <p className="text-gray-500">No plans saved.</p>;
@@ -82,11 +92,21 @@ export default function TrainingPlansList() {
               )}
             </div>
           </div>
-          {!plan.active && plan.id && (
-            <Button onClick={() => setActive(plan.id)} className="text-sm px-2 py-1">
-              Set Active
-            </Button>
-          )}
+          <div className="flex gap-2">
+            {!plan.active && plan.id && (
+              <Button onClick={() => setActive(plan.id)} className="text-sm px-2 py-1">
+                Set Active
+              </Button>
+            )}
+            {plan.id && (
+              <Button
+                onClick={() => deletePlan(plan.id!)}
+                className="text-sm px-2 py-1 bg-red-600 hover:bg-red-700"
+              >
+                Delete
+              </Button>
+            )}
+          </div>
         </Card>
       ))}
     </div>

--- a/src/lib/utils/__tests__/setRunDay.test.ts
+++ b/src/lib/utils/__tests__/setRunDay.test.ts
@@ -1,0 +1,34 @@
+import { setDayForRunType } from "../running/setRunDay";
+import { RunningPlanData } from "@maratypes/runningPlan";
+
+describe("setDayForRunType", () => {
+  it("sets day for all runs of given type", () => {
+    const plan: RunningPlanData = {
+      weeks: 1,
+      schedule: [
+        {
+          weekNumber: 1,
+          weeklyMileage: 10,
+          unit: "miles",
+          runs: [
+            {
+              type: "easy",
+              unit: "miles",
+              targetPace: { unit: "miles", pace: "10:00" },
+              mileage: 5,
+            },
+            {
+              type: "long",
+              unit: "miles",
+              targetPace: { unit: "miles", pace: "11:00" },
+              mileage: 10,
+            },
+          ],
+        },
+      ],
+    };
+    const result = setDayForRunType(plan, "easy", "Monday");
+    expect(result.schedule[0].runs[0].day).toBe("Monday");
+    expect(result.schedule[0].runs[1].day).toBeUndefined();
+  });
+});

--- a/src/lib/utils/running/setRunDay.ts
+++ b/src/lib/utils/running/setRunDay.ts
@@ -1,0 +1,16 @@
+import { RunningPlanData, PlannedRun } from "@maratypes/runningPlan";
+import { DayOfWeek } from "@maratypes/basics";
+
+export function setDayForRunType(
+  plan: RunningPlanData,
+  type: PlannedRun["type"],
+  day: DayOfWeek
+): RunningPlanData {
+  const schedule = plan.schedule.map((week) => ({
+    ...week,
+    runs: week.runs.map((run) =>
+      run.type === type ? { ...run, day } : run
+    ),
+  }));
+  return { ...plan, schedule };
+}


### PR DESCRIPTION
## Summary
- allow deleting training plans from the list
- enable editing of plans on the plan details page and save changes
- add bulk day-of-week setter in `RunningPlanDisplay`
- add helper for setting days across plan and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68479d45f67c8324afb337e53a4405a6