### PR TITLE
Replace useLocation with usePathname in NotFound page

### DIFF
--- a/src/app/NotFound.tsx
+++ b/src/app/NotFound.tsx
@@ -1,17 +1,19 @@
-import { useLocation } from "react-router-dom";
+"use client";
+
 import { useEffect } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Button } from "@components/ui";
 
 const NotFound = () => {
-  const location = useLocation();
+  const pathname = usePathname();
 
   useEffect(() => {
     console.error(
       "404 Error: User attempted to access non-existent route:",
-      location.pathname
+      pathname
     );
-  }, [location.pathname]);
+  }, [pathname]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">


### PR DESCRIPTION
## Summary
- switch NotFound component to `usePathname`
- remove `react-router-dom` usage

## Testing
- `npm run lint`
- `npm test`
- `npx next dev` *(fails: missing packages for Tailwind)*

------
https://chatgpt.com/codex/tasks/task_e_68487a1d673c8324917b9ae2e7048e7a