### PR TITLE
Refactor layout and styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,25 +3,8 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Define custom properties for theming */
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --primary: #813fdc;
-  --secondary: #9b6edbe1;
-  --accent: #bac4d6;
-}
-
-/* Dark mode styles using the prefers-color-scheme media query */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-    --primary: #813fdc;
-    --secondary: #9b6edbe1;
-    --accent: #bac4d6;
-  }
-}
+/* Global color variables */
+@import "../styles/theme.css";
 
 /* Global base styles */
 html,
@@ -60,9 +43,10 @@ a:hover {
 
 /* Utility classes for container width */
 .container {
-  width: 90%;
-  max-width: 1200px;
-  margin: 0 auto;
+  width: 100%;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin: 0;
 }
 
 /* Example global heading styles */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "@components/Providers";
 import Navbar from "@components/Navbar";
+import Footer from "@components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
         <Providers>
           <Navbar />
           {children}
+          <Footer />
         </Providers>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,7 @@ import { useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import LandingNavbar from "@components/LandingNavbar";
-import Footer from "@components/Footer";
+
 
 export default function LandingPage() {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -84,7 +83,6 @@ export default function LandingPage() {
 
   return (
     <main className="relative overflow-x-hidden text-foreground bg-transparent">
-      <LandingNavbar />
 
       {/* Full‐screen background video */}
       <video
@@ -154,7 +152,6 @@ export default function LandingPage() {
         </div>
       </section>
 
-      <Footer />
     </main>
   );
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,17 @@
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+  --primary: #813fdc;
+  --secondary: #9b6edbe1;
+  --accent: #bac4d6;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0a0a0a;
+    --foreground: #ededed;
+    --primary: #813fdc;
+    --secondary: #9b6edbe1;
+    --accent: #bac4d6;
+  }
+}
+


### PR DESCRIPTION
## Summary
- move color variables into `src/styles/theme.css`
- expose theme via `globals.css`
- adjust container utility to stretch full width
- add shared footer in root layout
- remove landing navbar and footer from landing page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848e4b5b9cc8324afeacbd63b666975