### PR TITLE
Centralize theme colors

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -71,7 +71,7 @@ export default function SignupPage() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Your Name"
-              className="w-full px-3 py-2 border border-gray-300 rounded bg-gray-200 focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 border border-accent rounded bg-background focus:ring-2 focus:ring-primary"
             />
           </div>
           <div>
@@ -82,7 +82,7 @@ export default function SignupPage() {
               value={avatarUrl}
               onChange={(e) => setAvatarUrl(e.target.value)}
               placeholder="https://example.com/avatar.png"
-              className="w-full px-3 py-2 border border-gray-300 rounded bg-gray-200 focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 border border-accent rounded bg-background focus:ring-2 focus:ring-primary"
             />
             <input
               type="file"
@@ -110,7 +110,7 @@ export default function SignupPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="w-full px-3 py-2 border border-gray-300 rounded bg-gray-200 focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 border border-accent rounded bg-background focus:ring-2 focus:ring-primary"
             />
           </div>
           <div>
@@ -123,12 +123,12 @@ export default function SignupPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Password"
-              className="w-full px-3 py-2 border border-gray-300 rounded bg-gray-200 focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 border border-accent rounded bg-background focus:ring-2 focus:ring-primary"
             />
           </div>
           <button
             type="submit"
-            className="w-full bg-primary text-white px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"
+            className="w-full bg-primary text-foreground px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"
           >
             Sign Up
           </button>

--- a/src/app/(auth)/userProfile/page.tsx
+++ b/src/app/(auth)/userProfile/page.tsx
@@ -69,7 +69,7 @@ export default function UserProfilePage() {
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
         <p>
           Please{" "}
-          <a href="/login" className="underline text-blue-600">
+          <a href="/login" className="underline text-primary">
             log in
           </a>{" "}
           to view your profile.
@@ -106,7 +106,7 @@ export default function UserProfilePage() {
         </button>
       </div>
       {saveSuccess && (
-        <div className="mb-4 text-green-600">Profile updated!</div>
+        <div className="mb-4 text-primary">Profile updated!</div>
       )}
       {profile && <UserProfileForm initialUser={profile} onSave={handleSave} />}
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,37 +3,8 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Define custom properties for theming */
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --primary: #813fdc;
-  --secondary: #9b6edbe1;
-  --accent: #bac4d6;
-  --brand-from: #f97316;
-  --brand-to: #3b82f6;
-  --brand-orange: #f97316;
-  --brand-blue: #3b82f6;
-  --brand-purple: #9333ea;
-  --brand-orange-dark: #ea580c;
-}
-
-/* Dark mode styles using the prefers-color-scheme media query */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-    --primary: #813fdc;
-    --secondary: #9b6edbe1;
-    --accent: #bac4d6;
-    --brand-from: #f97316;
-    --brand-to: #3b82f6;
-    --brand-orange: #f97316;
-    --brand-blue: #3b82f6;
-    --brand-purple: #9333ea;
-    --brand-orange-dark: #ea580c;
-  }
-}
+/* Import color variables */
+@import "../styles/theme.css";
 
 /* Global base styles */
 html,
@@ -85,13 +56,13 @@ p {
 input,
 select,
 textarea {
-  @apply bg-gray-300 text-black border border-gray-300 rounded px-2 py-1
+  @apply bg-background text-foreground border border-accent rounded px-2 py-1
          focus:outline-none focus:ring-2 focus:ring-primary;
 }
 
 button {
-  @apply bg-gray-400 text-black px-4 py-2 rounded hover:bg-gray-400
-         transition-colors focus:outline-none focus:ring-2 focus:ring-primary;
+  @apply bg-primary text-foreground px-4 py-2 rounded hover:bg-primary/80
+         transition-colors focus:outline-none focus:ring-2 focus:ring-secondary;
 }
 button.avatar-btn {
   @apply bg-transparent hover:bg-transparent p-0 text-transparent rounded-none focus:outline-none focus:ring-0;

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -70,10 +70,10 @@ export default function HomePage() {
             >
               Edit Profile
             </Link>
-            <div className="border rounded p-4 text-gray-500">
+            <div className="border rounded p-4 text-foreground/60">
               Upload workout file (coming soon)
             </div>
-            <div className="border rounded p-4 text-gray-500">
+            <div className="border rounded p-4 text-foreground/60">
               View progress analytics (coming soon)
             </div>
           </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -64,7 +64,7 @@ const LoginPage: React.FC = () => {
         <div className="flex justify-center">
           <button
             onClick={() => router.push("/home")}
-            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
+            className="bg-primary text-foreground px-4 py-2 rounded-md hover:bg-primary/80 transition-colors"
           >
             Go Home
           </button>
@@ -83,14 +83,14 @@ const LoginPage: React.FC = () => {
           <button
             type="button"
             onClick={jacksonLogin}
-            className="border px-4 py-2 rounded-md hover:bg-blue-50 transition"
+            className="border px-4 py-2 rounded-md hover:bg-accent/20 transition"
           >
             Jackson login
           </button>
         </div>
         <form onSubmit={handleLogin} className="space-y-4 w-full max-w-sm mx-auto">
           <div className="mb-4">
-            <label htmlFor="email" className="block text-gray-700 mb-2">
+            <label htmlFor="email" className="block text-foreground mb-2">
               Email:
             </label>
             <input
@@ -103,7 +103,7 @@ const LoginPage: React.FC = () => {
             />
           </div>
           <div className="mb-6">
-            <label htmlFor="password" className="block text-gray-700 mb-2">
+            <label htmlFor="password" className="block text-foreground mb-2">
               Password:
             </label>
             <input
@@ -117,17 +117,17 @@ const LoginPage: React.FC = () => {
           </div>
           <button
             type="submit"
-            className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition-colors"
+            className="w-full bg-primary text-foreground py-2 rounded-md hover:bg-primary/80 transition-colors"
           >
             Login
           </button>
           <div className="text-center my-4">
-            <span className="text-gray-500">or</span>
+            <span className="text-foreground/80">or</span>
           </div>
           <button
             type="button"
             onClick={() => router.push("/signup")}
-            className="w-full border border-blue-600 text-blue-600 py-2 rounded-md hover:bg-blue-50 transition-colors"
+            className="w-full border border-primary text-primary py-2 rounded-md hover:bg-primary/20 transition-colors"
           >
             Not registered? Sign up
           </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,15 +43,15 @@ export default function Landing() {
             </div>
             <div className="flex items-center justify-center space-x-8 text-sm text-muted-foreground">
               <div className="flex items-center">
-                <CheckCircle className="w-4 h-4 mr-2 text-green-500" />
+                <CheckCircle className="w-4 h-4 mr-2 text-primary" />
                 14-day free trial
               </div>
               <div className="flex items-center">
-                <CheckCircle className="w-4 h-4 mr-2 text-green-500" />
+                <CheckCircle className="w-4 h-4 mr-2 text-primary" />
                 No credit card required
               </div>
               <div className="flex items-center">
-                <CheckCircle className="w-4 h-4 mr-2 text-green-500" />
+                <CheckCircle className="w-4 h-4 mr-2 text-primary" />
                 Cancel anytime
               </div>
             </div>
@@ -92,8 +92,8 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border-0 bg-gradient-to-br from-green-50 to-white dark:from-green-950/10 dark:to-background hover:shadow-lg transition-all duration-300">
-              <div className="w-12 h-12 bg-gradient-to-br from-green-500 to-green-600 rounded-lg flex items-center justify-center mb-6">
+            <Card className="p-8 border-0 bg-gradient-to-br from-[var(--brand-from)] to-background hover:shadow-lg transition-all duration-300">
+              <div className="w-12 h-12 bg-gradient-to-br from-primary to-secondary rounded-lg flex items-center justify-center mb-6">
                 <Watch className="w-6 h-6 text-white" />
               </div>
               <h3 className="text-xl font-semibold mb-4">Seamless Device Integration</h3>
@@ -122,8 +122,8 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border-0 bg-gradient-to-br from-yellow-50 to-white dark:from-yellow-950/10 dark:to-background hover:shadow-lg transition-all duration-300">
-              <div className="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mb-6">
+            <Card className="p-8 border-0 bg-gradient-to-br from-[var(--brand-from)] to-background hover:shadow-lg transition-all duration-300">
+              <div className="w-12 h-12 bg-gradient-to-br from-secondary to-primary rounded-lg flex items-center justify-center mb-6">
                 <Award className="w-6 h-6 text-white" />
               </div>
               <h3 className="text-xl font-semibold mb-4">Proven Science</h3>
@@ -216,9 +216,9 @@ export default function Landing() {
               </div>
             </Card>
 
-            <Card className="p-8 border-0 bg-gradient-to-br from-white to-green-50 dark:from-background dark:to-green-950/10">
+            <Card className="p-8 border-0 bg-gradient-to-br from-background to-[var(--brand-from)]">
               <div className="flex items-center mb-6">
-                <div className="w-12 h-12 bg-green-500 rounded-full flex items-center justify-center text-white font-bold">
+                <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center text-foreground font-bold">
                   A
                 </div>
                 <div className="ml-4">
@@ -229,7 +229,7 @@ export default function Landing() {
               <p className="text-muted-foreground mb-4">
                 &quot;With work and kids, I thought Boston was impossible. Maratron adapted to my chaotic schedule and got me there.&quot;
               </p>
-              <div className="text-sm font-medium text-green-600">
+              <div className="text-sm font-medium text-primary">
                 Boston qualifier on limited training time
               </div>
             </Card>
@@ -249,7 +249,7 @@ export default function Landing() {
               Join the thousands of runners who&apos;ve discovered what&apos;s possible when science meets personalization. Your breakthrough is waiting.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button size="lg" className="bg-white text-gray-900 hover:bg-gray-100 text-lg px-8 py-6">
+              <Button size="lg" className="bg-background text-foreground hover:bg-accent/10 text-lg px-8 py-6">
                 Start Your Free Assessment
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Button>

--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -82,7 +82,7 @@ export default function PlanPage({ params }: PageProps) {
                 console.error(err);
               }
             }}
-            className="bg-green-600 ml-2"
+            className="bg-primary ml-2"
           >
             Save
           </Button>

--- a/src/components/LandingNavbar.tsx
+++ b/src/components/LandingNavbar.tsx
@@ -46,21 +46,21 @@ export default function Navbar() {
               <Link
                 href="#features"
                 onClick={() => setMenuOpen(false)}
-                className="px-2 py-1 text-gray-700 hover:bg-gray-100 rounded"
+                className="px-2 py-1 text-foreground hover:bg-accent/20 rounded"
               >
                 Learn More
               </Link>
               <Link
                 href="/login"
                 onClick={() => setMenuOpen(false)}
-                className="px-2 py-1 text-gray-700 hover:bg-gray-100 rounded"
+                className="px-2 py-1 text-foreground hover:bg-accent/20 rounded"
               >
                 Login
               </Link>
               <Link
                 href="/signup"
                 onClick={() => setMenuOpen(false)}
-                className="px-2 py-1 text-gray-700 hover:bg-gray-100 rounded"
+                className="px-2 py-1 text-foreground hover:bg-accent/20 rounded"
               >
                 Sign Up
               </Link>

--- a/src/components/PlanGenerator.tsx
+++ b/src/components/PlanGenerator.tsx
@@ -222,7 +222,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
           )}
           <button
             type="submit"
-            className="w-full bg-blue-500 text-white p-2 rounded hover:bg-blue-600"
+            className="w-full bg-primary text-foreground p-2 rounded hover:bg-primary/80"
           >
             Generate Plan
           </button>
@@ -252,7 +252,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
             <button
               type="button"
               onClick={() => setStartDate("")}
-              className="mt-1 text-sm underline text-blue-600"
+              className="mt-1 text-sm underline text-primary"
             >
               Clear
             </button>
@@ -270,7 +270,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
             <button
               type="button"
               onClick={() => setEndDate("")}
-              className="mt-1 text-sm underline text-blue-600"
+              className="mt-1 text-sm underline text-primary"
             >
               Clear
             </button>
@@ -299,7 +299,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
                   alert("Failed to save plan");
                 }
               }}
-              className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+              className="bg-primary text-foreground px-4 py-2 rounded hover:bg-primary/80"
             >
               Save Plan
             </button>
@@ -308,7 +308,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
               onClick={() => {
                 setEditPlan((prev) => !prev);
               }}
-              className="bg-yellow-500 text-white px-4 py-2 rounded hover:bg-yellow-600"
+              className="bg-secondary text-foreground px-4 py-2 rounded hover:bg-secondary/80"
             >
               Edit
             </button>
@@ -338,14 +338,14 @@ const [targetDistance, setTargetDistance] = useState<number>(
                     );
                     alert("JSON copied to clipboard!");
                   }}
-                  className="ml-2 text-blue-500 underline"
+                  className="ml-2 text-primary underline"
                 >
                   Copy JSON
                 </button>
               )}
             </label>
             {showJson && (
-              <pre className="bg-gray-100 p-4 rounded overflow-x-auto mt-2 text-gray-800">
+              <pre className="bg-background p-4 rounded overflow-x-auto mt-2 text-foreground">
                 {JSON.stringify(planData, null, 2)}
               </pre>
             )}

--- a/src/components/RecentRuns.tsx
+++ b/src/components/RecentRuns.tsx
@@ -36,9 +36,9 @@ export default function RecentRuns() {
     fetchRuns();
   }, [session?.user?.id]);
 
-  if (loading) return <p className="text-gray-500">Loading runs...</p>;
+  if (loading) return <p className="text-foreground/60">Loading runs...</p>;
   if (runs.length === 0)
-    return <p className="text-gray-500">No runs recorded yet.</p>;
+    return <p className="text-foreground/60">No runs recorded yet.</p>;
 
   return (
     <>

--- a/src/components/RunForm.tsx
+++ b/src/components/RunForm.tsx
@@ -167,7 +167,7 @@ const RunForm: React.FC<RunFormProps> = ({ onSubmit }) => {
     <Card className="p-6 w-full">
       <h2 className="text-2xl font-semibold mb-4">Add a Run</h2>
 
-      {success && <p className="text-green-600 mb-4">{success}</p>}
+      {success && <p className="text-primary mb-4">{success}</p>}
       {errors.length > 0 && (
         <div className="space-y-1 mb-4">
           {errors.map((err, i) => (
@@ -246,7 +246,7 @@ const RunForm: React.FC<RunFormProps> = ({ onSubmit }) => {
             onChange={handleFieldChange}
           />
         ) : (
-          <p className="text-sm text-gray-600">Add a shoe to track mileage.</p>
+          <p className="text-sm text-foreground/60">Add a shoe to track mileage.</p>
         )}
 
         <div className="grid grid-cols-2 gap-4">

--- a/src/components/RunModal.tsx
+++ b/src/components/RunModal.tsx
@@ -14,27 +14,27 @@ export default function RunModal({ run, onClose }: RunModalProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <Card className="relative w-1/2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg w-full">
+      <Card className="relative w-1/2 bg-background p-6 rounded-lg shadow-lg w-full">
         <button
           aria-label="Close"
           onClick={onClose}
           className="
-            absolute 
-            top-2 right-2 
-            bg-transparent 
-            text-2xl font-bold 
-            text-gray-500 dark:text-gray-300 
-            hover:text-gray-200 dark:hover:text-white 
+            absolute
+            top-2 right-2
+            bg-transparent
+            text-2xl font-bold
+            text-foreground/60 dark:text-foreground/60
+            hover:text-foreground
             focus:outline-none
           "
         >
           ×
         </button>
 
-        <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
+        <h2 className="text-lg font-semibold mb-4 text-foreground">
           {run.name || getRunName(run)}
         </h2>
-        <div className="space-y-2 text-sm text-gray-800 dark:text-gray-200">
+        <div className="space-y-2 text-sm text-foreground">
           <p>
             <span className="font-semibold">Distance:</span> {run.distance}{" "}
             {run.distanceUnit}

--- a/src/components/RunningPlanDisplay.tsx
+++ b/src/components/RunningPlanDisplay.tsx
@@ -82,17 +82,17 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
 
   return (
     <div
-      className={`border border-gray-300 rounded shadow-sm mb-4 ${
-        isWeekComplete ? "bg-gray-100 text-gray-500" : ""
+      className={`border border-accent rounded shadow-sm mb-4 ${
+        isWeekComplete ? "bg-background text-foreground/60" : ""
       }`}
     >
       <div
         className={`flex justify-between items-center p-4 cursor-pointer ${
-          isWeekComplete ? "bg-gray-500" : "bg-gray-300"
+          isWeekComplete ? "bg-accent" : "bg-accent/30"
         }`}
         onClick={() => setIsOpen((prev) => !prev)}
       >
-        <h3 className="text-xl font-semibold text-gray-800">
+        <h3 className="text-xl font-semibold text-foreground">
           Week {weekPlan.weekNumber}
           {weekPlan.phase && ` – ${weekPlan.phase} phase`} - Total Mileage:
           {" "}
@@ -103,8 +103,8 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
       </div>
       {isOpen && (
         <div
-          className={`p-4 text-gray-800 ${
-            isWeekComplete ? "bg-gray-200" : "bg-gray-400"
+          className={`p-4 text-foreground ${
+            isWeekComplete ? "bg-background" : "bg-accent/50"
           }`}
         >
           <p className="mb-2">Start: {weekPlan.startDate?.slice(0, 10)}</p>
@@ -113,11 +113,11 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
             {weekPlan.runs.map((run, index) => {
               const past = run.date ? new Date(run.date) < new Date() : false;
               const classes =
-                past || run.done ? "text-gray-500 line-through" : "";
+                past || run.done ? "text-foreground/60 line-through" : "";
               return (
                 <li
                   key={index}
-                  className={`border-t border-gray-300 pt-2 space-y-1 ${classes}`}
+                  className={`border-t border-accent pt-2 space-y-1 ${classes}`}
                 >
                   {editable ? (
                     <div className="space-y-1">
@@ -133,7 +133,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                               e.target.value
                             )
                           }
-                          className="border p-1 rounded text-black"
+                          className="border p-1 rounded text-foreground"
                         >
                           {runTypes.map((t) => (
                             <option key={t} value={t}>
@@ -156,7 +156,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                               Math.round(Number(e.target.value) * 10) / 10
                             )
                           }
-                          className="border p-1 rounded text-black"
+                          className="border p-1 rounded text-foreground"
                         />
                         <span className="ml-1">{run.unit}</span>
                       </label>
@@ -171,7 +171,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                               pace: formatPace(parsePace(e.target.value)),
                             })
                           }
-                          className="border p-1 rounded text-black"
+                          className="border p-1 rounded text-foreground"
                         />
                       </label>
                       <label className="block">
@@ -186,7 +186,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                               e.target.value as DayOfWeek
                             )
                           }
-                          className="border p-1 rounded text-black"
+                          className="border p-1 rounded text-foreground"
                         >
                           {days.map((d) => (
                             <option key={d} value={d}>
@@ -203,7 +203,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                           onChange={(e) =>
                             updateRun(weekIndex, index, "notes", e.target.value)
                           }
-                          className="border p-1 rounded text-black w-full"
+                          className="border p-1 rounded text-foreground w-full"
                         />
                       </label>
                       <label className="block">
@@ -313,7 +313,7 @@ const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange })
       <select
         value={type}
         onChange={(e) => setType(e.target.value as PlannedRun["type"])}
-        className="border p-1 rounded text-black"
+        className="border p-1 rounded text-foreground"
       >
         {runTypes.map((t) => (
           <option key={t} value={t}>
@@ -325,7 +325,7 @@ const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange })
       <select
         value={day}
         onChange={(e) => setDay(e.target.value as DayOfWeek)}
-        className="border p-1 rounded text-black"
+        className="border p-1 rounded text-foreground"
       >
         {days.map((d) => (
           <option key={d} value={d}>
@@ -336,7 +336,7 @@ const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange })
       <button
         type="button"
         onClick={apply}
-        className="bg-blue-500 text-white px-3 py-1 rounded"
+        className="bg-primary text-foreground px-3 py-1 rounded"
       >
         Apply
       </button>

--- a/src/components/ShoeForm.tsx
+++ b/src/components/ShoeForm.tsx
@@ -121,7 +121,7 @@ const ShoeForm: React.FC<ShoeFormProps> = ({ onSubmit, initialData }) => {
     <Card className="p-6 w-full">
       <h2 className="text-2xl font-semibold mb-4">Add a Shoe</h2>
 
-      {success && <p className="text-green-600 mb-4">{success}</p>}
+      {success && <p className="text-primary mb-4">{success}</p>}
       {errors.length > 0 && (
         <div className="space-y-1 mb-4">
           {errors.map((err, i) => (

--- a/src/components/ShoesList.tsx
+++ b/src/components/ShoesList.tsx
@@ -41,9 +41,9 @@ export default function ShoesList() {
     }
   };
 
-  if (loading) return <p className="text-gray-500">Loading shoes...</p>;
+  if (loading) return <p className="text-foreground/60">Loading shoes...</p>;
   if (shoes.length === 0)
-    return <p className="text-gray-500">No shoes added.</p>;
+    return <p className="text-foreground/60">No shoes added.</p>;
 
   return (
     <div className="space-y-2">
@@ -63,7 +63,7 @@ export default function ShoesList() {
                   {shoe.currentDistance} / {shoe.maxDistance} {shoe.distanceUnit}
                 </span>
                 {isDefault && (
-                  <span className="ml-2 text-green-600 font-medium">default</span>
+                  <span className="ml-2 text-primary font-medium">default</span>
                 )}
               </div>
             </div>

--- a/src/components/TrainingPlansList.tsx
+++ b/src/components/TrainingPlansList.tsx
@@ -66,9 +66,9 @@ export default function TrainingPlansList() {
     }
   };
 
-  if (loading) return <p className="text-gray-500">Loading plans...</p>;
+  if (loading) return <p className="text-foreground/60">Loading plans...</p>;
   if (plans.length === 0)
-    return <p className="text-gray-500">No plans saved.</p>;
+    return <p className="text-foreground/60">No plans saved.</p>;
 
   return (
     <div className="space-y-2">
@@ -88,7 +88,7 @@ export default function TrainingPlansList() {
                 </span>
               )}
               {plan.active && (
-                <span className="ml-2 text-green-600 font-medium">active</span>
+                <span className="ml-2 text-primary font-medium">active</span>
               )}
             </div>
           </div>

--- a/src/components/UserProfileForm/Section.module.css
+++ b/src/components/UserProfileForm/Section.module.css
@@ -1,16 +1,16 @@
 /* Section.module.css */
 .card {
-  @apply bg-gray-800 p-6 rounded-lg;
+  @apply bg-background p-6 rounded-lg;
 }
 .title {
-  @apply text-xl font-semibold mb-4 text-white;
+  @apply text-xl font-semibold mb-4 text-foreground;
 }
 .list {
   @apply grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4;
 }
 .label {
-  @apply text-sm font-medium text-gray-400;
+  @apply text-sm font-medium text-foreground/70;
 }
 .value {
-  @apply mt-1 text-white;
+  @apply mt-1 text-foreground;
 }

--- a/src/components/UserProfileForm/index.tsx
+++ b/src/components/UserProfileForm/index.tsx
@@ -38,18 +38,18 @@ export default function UserProfileForm({
         e.preventDefault();
         handleSave();
       }}
-      className="bg-gray-800 p-6 rounded-lg shadow-lg space-y-6"
+      className="bg-background p-6 rounded-lg shadow-lg space-y-6"
     >
-      <div className="flex justify-between items-center border-b border-gray-700 pb-4">
-        <h2 className="text-3xl font-bold text-white">Your Profile</h2>
+      <div className="flex justify-between items-center border-b border-accent pb-4">
+        <h2 className="text-3xl font-bold text-foreground">Your Profile</h2>
         {!alwaysEdit && (
           <button
             type="button"
             onClick={toggleEditing}
-            className={`px-4 py-2 rounded font-medium text-white ${
+            className={`px-4 py-2 rounded font-medium text-foreground ${
               editing
-                ? "bg-gray-600 hover:bg-gray-500"
-                : "bg-blue-600 hover:bg-blue-700"
+                ? "bg-accent hover:bg-accent/80"
+                : "bg-primary hover:bg-primary/80"
             }`}
           >
             {editing ? "Cancel" : "Edit"}
@@ -92,7 +92,7 @@ export default function UserProfileForm({
         <div className="mt-6 flex justify-end">
           <button
             type="submit"
-            className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-2 rounded transition-colors"
+            className="w-full sm:w-auto bg-primary hover:bg-primary/80 text-foreground font-semibold px-6 py-2 rounded transition-colors"
           >
             {submitLabel}
           </button>

--- a/src/components/WeeklyRuns.tsx
+++ b/src/components/WeeklyRuns.tsx
@@ -43,8 +43,8 @@ export default function WeeklyRuns() {
     fetchPlan();
   }, [session?.user?.id, refresh]);
 
-  if (loading) return <p className="text-gray-500">Loading...</p>;
-  if (!plan) return <p className="text-gray-500">No active plan.</p>;
+  if (loading) return <p className="text-foreground/60">Loading...</p>;
+  if (!plan) return <p className="text-foreground/60">No active plan.</p>;
 
   let weekIndex: number;
   if (plan.planData.startDate) {
@@ -60,13 +60,13 @@ export default function WeeklyRuns() {
   }
   if (weekIndex < 0) {
     return (
-      <p className="text-gray-500">
+      <p className="text-foreground/60">
         {plan.name} training begins {plan.planData.startDate?.slice(0, 10)}
       </p>
     );
   }
   if (!plan.planData.schedule[weekIndex]) {
-    return <p className="text-gray-500">Plan completed!</p>;
+    return <p className="text-foreground/60">Plan completed!</p>;
   }
   const week = plan.planData.schedule[weekIndex];
 
@@ -134,7 +134,7 @@ export default function WeeklyRuns() {
       <Progress value={progressValue} />
       <div className="space-y-2">
         {week.runs.map((r, i) => {
-          const classes = r.done ? "text-gray-500 line-through" : undefined;
+          const classes = r.done ? "text-foreground/60 line-through" : undefined;
           return (
             <Card key={i} className={`flex items-center justify-between ${classes}`}>
               <div>

--- a/src/components/ui/FormField/CheckboxGroupField.tsx
+++ b/src/components/ui/FormField/CheckboxGroupField.tsx
@@ -47,16 +47,16 @@ const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
                   onChange(name, next);
                 }}
                 value={opt.value}
-                className="rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+                className="rounded border-accent text-primary focus:ring-2 focus:ring-primary"
               />
-              <span className="ml-2 text-gray-700 dark:text-gray-300">
+              <span className="ml-2 text-foreground dark:text-foreground">
                 {opt.label}
               </span>
             </label>
           ))}
         </div>
       ) : (
-        <p className="mt-1 text-gray-700 dark:text-gray-300">
+        <p className="mt-1 text-foreground dark:text-foreground">
           {value.length > 0 ? value.join(", ") : "–"}
         </p>
       )}

--- a/src/components/ui/FormField/SelectField.tsx
+++ b/src/components/ui/FormField/SelectField.tsx
@@ -49,7 +49,7 @@ const SelectField: React.FC<SelectFieldProps> = ({
           ))}
         </select>
       ) : (
-        <p className="mt-1 text-gray-700 dark:text-gray-300">
+        <p className="mt-1 text-foreground dark:text-foreground">
           {options.find((opt) => opt.value === value)?.label ?? "–"}
         </p>
       )}

--- a/src/components/ui/FormField/TextAreaField.tsx
+++ b/src/components/ui/FormField/TextAreaField.tsx
@@ -38,7 +38,7 @@ const TextAreaField: React.FC<TextAreaFieldProps> = ({
           {...props}
         />
       ) : (
-        <p className="mt-1 text-gray-700 dark:text-gray-300">{value ?? "–"}</p>
+        <p className="mt-1 text-foreground dark:text-foreground">{value ?? "–"}</p>
       )}
     </div>
   );

--- a/src/components/ui/FormField/TextField.tsx
+++ b/src/components/ui/FormField/TextField.tsx
@@ -39,7 +39,7 @@ const TextField: React.FC<TextFieldProps> = ({
           {...inputProps}
         />
       ) : (
-        <p className="mt-1 text-gray-700 dark:text-gray-300">{value ?? "–"}</p>
+        <p className="mt-1 text-foreground dark:text-foreground">{value ?? "–"}</p>
       )}
     </div>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,10 +7,10 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-white hover:bg-primary/90",
+        default: "bg-primary text-foreground hover:bg-primary/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-foreground",
-        secondary: "bg-secondary text-white hover:bg-secondary/80",
-        destructive: "bg-red-600 text-white hover:bg-red-700",
+        secondary: "bg-secondary text-foreground hover:bg-secondary/80",
+        destructive: "bg-red-600 text-foreground hover:bg-red-700",
         ghost: "hover:bg-accent/20",
       },
       size: {

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -14,7 +14,7 @@ export const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md bg-gray-900 px-2 py-1.5 text-sm text-white shadow-md",
+      "z-50 overflow-hidden rounded-md bg-accent px-2 py-1.5 text-sm text-foreground shadow-md",
       className
     )}
     {...props}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,29 @@
+:root {
+  --background: #d4d4d8;
+  --foreground: #4e545c;
+  --primary: #20c1ec;
+  --secondary: #1f81a8;
+  --accent: #293b54;
+  --brand-from: #20c1ec;
+  --brand-to: #1f81a8;
+  --brand-orange: #2b5976;
+  --brand-blue: #1f81a8;
+  --brand-purple: #343444;
+  --brand-orange-dark: #544a5c;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #141b2b;
+    --foreground: #d4d4d8;
+    --primary: #20c1ec;
+    --secondary: #1f81a8;
+    --accent: #223443;
+    --brand-from: #20c1ec;
+    --brand-to: #1f81a8;
+    --brand-orange: #2b5976;
+    --brand-blue: #1f81a8;
+    --brand-purple: #343444;
+    --brand-orange-dark: #544a5c;
+  }
+}


### PR DESCRIPTION
## Summary
- move color variables to `src/styles/theme.css`
- import theme in global stylesheet
- replace hard-coded colors with theme variables across components
- adjust default button text colors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848eada95208324872e0cf9aafc5af3