### PR TITLE
Improve home dashboard UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@prisma/client": "^6.4.1",
         "axios": "^1.7.9",
         "framer-motion": "^12.16.0",
+        "lucide-react": "^0.514.0",
         "next": "15.2.3",
         "next-auth": "^4.24.11",
         "react": "^19.0.0",
@@ -7849,6 +7850,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.514.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.514.0.tgz",
+      "integrity": "sha512-HXD0OAMd+JM2xCjlwG1EGW9Nuab64dhjO3+MvdyD+pSUeOTBaVAPhQblKIYmmX4RyBYbdzW0VWnJpjJmxWGr6w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@prisma/client": "^6.4.1",
     "axios": "^1.7.9",
     "framer-motion": "^12.16.0",
+    "lucide-react": "^0.514.0",
     "next": "15.2.3",
     "next-auth": "^4.24.11",
     "react": "^19.0.0",

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -6,6 +6,16 @@ import RecentRuns from "@components/RecentRuns";
 import TrainingPlansList from "@components/TrainingPlansList";
 import WeeklyRuns from "@components/WeeklyRuns";
 import ShoesList from "@components/ShoesList";
+import DashboardStats from "@components/DashboardStats";
+import { Card } from "@components/ui";
+import {
+  PlusCircle,
+  ClipboardList,
+  Shoe,
+  User as UserIcon,
+  Upload,
+  BarChart2,
+} from "lucide-react";
 
 export default function HomePage() {
   const { data: session, status } = useSession();
@@ -35,41 +45,45 @@ export default function HomePage() {
     <main className="min-h-screen bg-background text-foreground p-4 space-y-10">
       <h1 className="text-3xl font-bold">Welcome back, {userName}!</h1>
 
+      <DashboardStats />
+
       <section>
         <h2 className="text-2xl font-semibold mb-4">Quick Actions</h2>
         {/* Wrap grid in a max-width container */}
         <div className="max-w-4xl mx-auto">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Link
-              href="/runs/new"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Add a Run
+            <Link href="/runs/new" className="block">
+              <Card className="flex items-center gap-2 hover:bg-accent/10 transition">
+                <PlusCircle className="text-primary" />
+                <span>Add a Run</span>
+              </Card>
             </Link>
-            <Link
-              href="/plan-generator"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Generate Training Plan
+            <Link href="/plan-generator" className="block">
+              <Card className="flex items-center gap-2 hover:bg-accent/10 transition">
+                <ClipboardList className="text-primary" />
+                <span>Generate Training Plan</span>
+              </Card>
             </Link>
-            <Link
-              href="/shoes/new"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Add New Shoes
+            <Link href="/shoes/new" className="block">
+              <Card className="flex items-center gap-2 hover:bg-accent/10 transition">
+                <Shoe className="text-primary" />
+                <span>Add New Shoes</span>
+              </Card>
             </Link>
-            <Link
-              href="/userProfile"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Edit Profile
+            <Link href="/userProfile" className="block">
+              <Card className="flex items-center gap-2 hover:bg-accent/10 transition">
+                <UserIcon className="text-primary" />
+                <span>Edit Profile</span>
+              </Card>
             </Link>
-            <div className="border rounded p-4 text-gray-500">
-              Upload workout file (coming soon)
-            </div>
-            <div className="border rounded p-4 text-gray-500">
-              View progress analytics (coming soon)
-            </div>
+            <Card className="flex items-center gap-2 text-gray-500">
+              <Upload />
+              <span>Upload workout file (coming soon)</span>
+            </Card>
+            <Card className="flex items-center gap-2 text-gray-500">
+              <BarChart2 />
+              <span>View progress analytics (coming soon)</span>
+            </Card>
           </div>
         </div>
       </section>

--- a/src/components/DashboardStats.tsx
+++ b/src/components/DashboardStats.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { listRuns } from "@lib/api/run";
+import { listRunningPlans } from "@lib/api/plan";
+import { Card } from "@components/ui";
+import { Activity, Flag, ClipboardList } from "lucide-react";
+
+export default function DashboardStats() {
+  const { data: session } = useSession();
+  const [totalRuns, setTotalRuns] = useState(0);
+  const [totalDistance, setTotalDistance] = useState(0);
+  const [activePlan, setActivePlan] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!session?.user?.id) return;
+      try {
+        const runs = await listRuns();
+        const userRuns = runs.filter((r) => r.userId === session.user.id);
+        setTotalRuns(userRuns.length);
+        setTotalDistance(
+          userRuns.reduce((sum, r) => sum + r.distance, 0)
+        );
+
+        const plans = await listRunningPlans();
+        const active = plans.find(
+          (p) => p.userId === session.user?.id && p.active
+        );
+        setActivePlan(active?.name ?? null);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [session?.user?.id]);
+
+  if (loading) return <p className="text-gray-500">Loading summary...</p>;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-4xl mx-auto">
+      <Card className="flex items-center space-x-4">
+        <Activity className="text-primary" />
+        <div>
+          <p className="text-2xl font-bold">{totalRuns}</p>
+          <p className="text-sm text-foreground/70">Total Runs</p>
+        </div>
+      </Card>
+      <Card className="flex items-center space-x-4">
+        <Flag className="text-primary" />
+        <div>
+          <p className="text-2xl font-bold">{totalDistance.toFixed(1)}</p>
+          <p className="text-sm text-foreground/70">Total Distance</p>
+        </div>
+      </Card>
+      <Card className="flex items-center space-x-4">
+        <ClipboardList className="text-primary" />
+        <div>
+          <p className="text-lg font-semibold">
+            {activePlan || "No Active Plan"}
+          </p>
+          <p className="text-sm text-foreground/70">Training Plan</p>
+        </div>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add lucide-react dependency
- create `DashboardStats` component to show user run statistics and active plan
- enhance `/home` page with new stats section
- style Quick Actions using `Card` components and icons

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f0fc314c8324b136394733f275d3