### PR TITLE
Improve accent colors and home UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,8 +58,8 @@ p {
 input,
 select,
 textarea {
-  @apply bg-background text-foreground border border-accent rounded px-2 py-1
-         focus:outline-none focus:ring-2 focus:ring-primary;
+  @apply bg-accent-2/10 text-foreground border border-accent-2 rounded px-2 py-1
+         focus:outline-none focus:ring-2 focus:ring-accent-2;
 }
 
 button {

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -6,7 +6,16 @@ import RecentRuns from "@components/RecentRuns";
 import TrainingPlansList from "@components/TrainingPlansList";
 import WeeklyRuns from "@components/WeeklyRuns";
 import ShoesList from "@components/ShoesList";
-import { Skeleton } from "@components/ui";
+import DashboardStats from "@components/DashboardStats";
+import { Card, Skeleton } from "@components/ui";
+import {
+  PlusCircle,
+  CalendarCheck,
+  Shoe,
+  User,
+  Upload,
+  BarChart3,
+} from "lucide-react";
 
 export default function HomePage() {
   const { data: session, status } = useSession();
@@ -41,42 +50,45 @@ export default function HomePage() {
     <main className="w-full px-4 sm:px-6 lg:px-8 min-h-screen bg-background text-foreground space-y-10 pb-20">
       <h1 className="text-3xl font-bold">Welcome back, {userName}!</h1>
       <div className="h-1 w-24 mb-6 bg-gradient-to-r from-brand-from to-brand-to rounded"></div>
+      <DashboardStats />
 
       <section>
         <h2 className="text-2xl font-bold mb-4 border-b-2 border-primary inline-block pb-1">Quick Actions</h2>
         {/* Wrap grid in a max-width container */}
         <div className="w-full px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Link
-              href="/runs/new"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Add a Run
+            <Link href="/runs/new">
+              <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+                <PlusCircle className="w-5 h-5" />
+                <span>Add a Run</span>
+              </Card>
             </Link>
-            <Link
-              href="/plan-generator"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Generate Training Plan
+            <Link href="/plan-generator">
+              <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+                <CalendarCheck className="w-5 h-5" />
+                <span>Generate Training Plan</span>
+              </Card>
             </Link>
-            <Link
-              href="/shoes/new"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Add New Shoes
+            <Link href="/shoes/new">
+              <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+                <Shoe className="w-5 h-5" />
+                <span>Add New Shoes</span>
+              </Card>
             </Link>
-            <Link
-              href="/userProfile"
-              className="border rounded p-4 hover:bg-accent/20"
-            >
-              Edit Profile
+            <Link href="/userProfile">
+              <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+                <User className="w-5 h-5" />
+                <span>Edit Profile</span>
+              </Card>
             </Link>
-            <div className="border rounded p-4 text-foreground/60">
-              Upload workout file (coming soon)
-            </div>
-            <div className="border rounded p-4 text-foreground/60">
-              View progress analytics (coming soon)
-            </div>
+            <Card className="p-4 flex items-center gap-2 text-foreground/60">
+              <Upload className="w-5 h-5" />
+              <span>Upload workout file (coming soon)</span>
+            </Card>
+            <Card className="p-4 flex items-center gap-2 text-foreground/60">
+              <BarChart3 className="w-5 h-5" />
+              <span>View progress analytics (coming soon)</span>
+            </Card>
           </div>
         </div>
       </section>

--- a/src/components/DashboardStats.tsx
+++ b/src/components/DashboardStats.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { listRuns } from "@lib/api/run";
+import { Card } from "@components/ui";
+
+export default function DashboardStats() {
+  const { data: session } = useSession();
+  const [runCount, setRunCount] = useState(0);
+  const [totalDistance, setTotalDistance] = useState(0);
+
+  useEffect(() => {
+    async function fetchRuns() {
+      try {
+        const runs = await listRuns();
+        const filtered = session?.user
+          ? runs.filter((r) => r.userId === session.user.id)
+          : runs;
+        setRunCount(filtered.length);
+        setTotalDistance(
+          filtered.reduce((sum, r) => sum + r.distance, 0)
+        );
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchRuns();
+  }, [session?.user]);
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <Card className="p-4 text-center">
+        <div className="text-2xl font-bold">{runCount}</div>
+        <div className="text-sm text-muted-foreground">Total Runs</div>
+      </Card>
+      <Card className="p-4 text-center">
+        <div className="text-2xl font-bold">{totalDistance.toFixed(1)}</div>
+        <div className="text-sm text-muted-foreground">Total Distance</div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-accent-2 bg-accent-2/10 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -14,7 +14,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-10 w-full items-center justify-between rounded-md border border-accent-2 bg-accent-2/10 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     <textarea
       ref={ref}
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-md border border-accent-2 bg-accent-2/10 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -4,6 +4,8 @@
   --primary-rgb: 32, 193, 236;    /* #20c1ec */
   --secondary-rgb: 31, 129, 168;  /* #1f81a8 */
   --accent-rgb: 41, 59, 84;       /* #293b54 */
+  --accent-2-rgb: 246, 173, 85;  /* #F6AD55 */
+  --accent-3-rgb: 108, 185, 255; /* #6CB9FF */
   --brand-from: #20c1ec;
   --brand-to: #1f81a8;
   --brand-orange: #2b5976;
@@ -19,6 +21,8 @@
     --primary-rgb: 32, 193, 236;    /* #20c1ec */
     --secondary-rgb: 31, 129, 168;  /* #1f81a8 */
     --accent-rgb: 41, 59, 84;       /* #293b54 */
+    --accent-2-rgb: 246, 173, 85;  /* #F6AD55 */
+    --accent-3-rgb: 108, 185, 255; /* #6CB9FF */
     --brand-from: #20c1ec;
     --brand-to: #1f81a8;
     --brand-orange: #2b5976;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,14 @@ export default {
           opacityValue !== undefined
             ? `rgb(var(--accent-rgb) / ${opacityValue})`
             : `rgb(var(--accent-rgb))`,
+        "accent-2": ({ opacityValue }) =>
+          opacityValue !== undefined
+            ? `rgb(var(--accent-2-rgb) / ${opacityValue})`
+            : `rgb(var(--accent-2-rgb))`,
+        "accent-3": ({ opacityValue }) =>
+          opacityValue !== undefined
+            ? `rgb(var(--accent-3-rgb) / ${opacityValue})`
+            : `rgb(var(--accent-3-rgb))`,
         "brand-from": "var(--brand-from)",
         "brand-to": "var(--brand-to)",
         "brand-orange": "var(--brand-orange)",


### PR DESCRIPTION
## Summary
- add two global accent colors
- apply accent colors to form fields
- create `DashboardStats` component
- revamp Quick Actions with icons and cards
- insert DashboardStats on home page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f59f81b483248b9af6108014eabb