### PR TITLE
Style signup profile page

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,7 +3,7 @@
 import { useState, FormEvent } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { createUserProfile, uploadAvatar } from "@lib/api/user/user"; // Adjust path if necessary
+import { createUserProfile } from "@lib/api/user/user";
 import { Card, Input, Label, Button } from "@components/ui";
 
 
@@ -11,18 +11,8 @@ export default function SignupPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [avatarUrl, setAvatarUrl] = useState("");
   const [error, setError] = useState("");
   const router = useRouter();
-
-  const handleFileChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const url = await uploadAvatar(file);
-    setAvatarUrl(url);
-  };
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -32,7 +22,7 @@ export default function SignupPage() {
     }
 
     try {
-      const createUserRes = await createUserProfile({ name, email, avatarUrl });
+      const createUserRes = await createUserProfile({ name, email });
 
       if (createUserRes?.status === 201 || createUserRes?.status === 200) {
         // Now sign in the new user

--- a/src/app/(auth)/signup/profile/page.tsx
+++ b/src/app/(auth)/signup/profile/page.tsx
@@ -6,6 +6,7 @@ import { updateUserProfile } from "@lib/api/user/user";
 import UserProfileForm from "@components/UserProfileForm";
 import { UserProfile } from "@maratypes/user";
 import { useEffect } from "react";
+import { Card } from "@components/ui";
 
 export default function OnboardingProfile() {
   const { data: session, status, update } = useSession();
@@ -42,16 +43,23 @@ export default function OnboardingProfile() {
   };
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-12">
-      <h1 className="text-2xl font-bold mb-4">
-        Almost done—tell us about your running!
-      </h1>
-      <UserProfileForm
-        initialUser={initialUser}
-        onSave={onSave}
-        alwaysEdit
-        submitLabel="Finish Setup"
-      />
+    <div className="min-h-screen bg-background">
+      <section className="relative py-20 overflow-hidden flex items-center justify-center">
+        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" />
+        <div className="relative w-full px-4 sm:px-6 lg:px-8 flex justify-center">
+          <Card className="w-full max-w-2xl p-8 bg-white/90 dark:bg-white/10 shadow-xl space-y-6">
+            <h1 className="text-3xl font-bold text-center">
+              Almost done—tell us about your running!
+            </h1>
+            <UserProfileForm
+              initialUser={initialUser}
+              onSave={onSave}
+              alwaysEdit
+              submitLabel="Finish Setup"
+            />
+          </Card>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/UserProfileForm/BasicInfoSection.tsx
+++ b/src/components/UserProfileForm/BasicInfoSection.tsx
@@ -1,9 +1,8 @@
-import { TextField, SelectField } from "@components/ui";
+import { TextField, SelectField, AvatarUpload } from "@components/ui";
 import { UserProfile } from "@maratypes/user";
 import styles from "./Section.module.css";
 import type { Gender } from "@maratypes/user";
 import Image from "next/image";
-import { uploadAvatar } from "@lib/api/user/user";
 
 // runtime list of gender options
 const genderValues: Gender[] = ["Male", "Female", "Other"];
@@ -28,14 +27,6 @@ export default function BasicInfoSection({
   const handleFieldChange = (name: string, value: string) =>
     onChange(name as keyof UserProfile, value);
 
-  const handleFileChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const url = await uploadAvatar(file);
-    onChange("avatarUrl", url);
-  };
 
   return (
     <section className={styles.card}>
@@ -43,27 +34,11 @@ export default function BasicInfoSection({
       {isEditing ? (
         <div>
           <div className="flex items-center space-x-4 mb-4">
-          <Image
-            src={formData.avatarUrl || "/Default_pfp.svg"}
-            alt="Avatar preview"
-            width={80}
-            height={80}
-            className="w-20 h-20 rounded-full object-cover"
-          />
-          <TextField
-            label="Avatar URL"
-            name="avatarUrl"
-            value={formData.avatarUrl || ""}
-            editing={isEditing}
-            onChange={handleFieldChange}
-          />
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleFileChange}
-            className="mt-4"
-          />
-        </div>
+            <AvatarUpload
+              value={formData.avatarUrl}
+              onChange={(url) => onChange("avatarUrl", url)}
+            />
+          </div>
           <TextField
             label="Name"
             name="name"

--- a/src/components/UserProfileForm/index.tsx
+++ b/src/components/UserProfileForm/index.tsx
@@ -6,6 +6,7 @@ import PhysicalStatsSection from "./PhysicalStatsSection";
 import GoalsSection from "./GoalsSection";
 import PreferencesSection from "./PreferencesSection";
 import { useUserProfileForm } from "@hooks/useUserProfileForm";
+import { Button } from "@components/ui";
 
 interface Props {
   initialUser: UserProfile;
@@ -43,7 +44,7 @@ export default function UserProfileForm({
       <div className="flex justify-between items-center border-b border-accent pb-4">
         <h2 className="text-3xl font-bold text-foreground">Your Profile</h2>
         {!alwaysEdit && (
-          <button
+          <Button
             type="button"
             onClick={toggleEditing}
             className={`px-4 py-2 rounded font-medium text-foreground ${
@@ -53,7 +54,7 @@ export default function UserProfileForm({
             }`}
           >
             {editing ? "Cancel" : "Edit"}
-          </button>
+          </Button>
         )}
       </div>
 
@@ -90,12 +91,12 @@ export default function UserProfileForm({
 
       {editing && (
         <div className="mt-6 flex justify-end">
-          <button
+          <Button
             type="submit"
-            className="w-full sm:w-auto bg-primary hover:bg-primary/80 text-foreground font-semibold px-6 py-2 rounded transition-colors"
+            className="w-full sm:w-auto bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] text-white border-0 hover:from-[var(--brand-from)]/90 hover:to-[var(--brand-to)]/90"
           >
             {submitLabel}
-          </button>
+          </Button>
         </div>
       )}
     </form>

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -1,0 +1,48 @@
+import { useRef } from "react";
+import { Avatar, AvatarImage, AvatarFallback, Button } from "@components/ui";
+import { uploadAvatar } from "@lib/api/user/user";
+
+interface AvatarUploadProps {
+  value?: string;
+  onChange?: (url: string) => void;
+  disabled?: boolean;
+}
+
+export default function AvatarUpload({ value, onChange, disabled }: AvatarUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const url = await uploadAvatar(file);
+    onChange?.(url);
+  };
+
+  return (
+    <div className="flex items-center space-x-4">
+      <Avatar className="h-20 w-20">
+        <AvatarImage src={value || "/Default_pfp.svg"} alt="Avatar preview" />
+        <AvatarFallback>?</AvatarFallback>
+      </Avatar>
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled}
+        >
+          Upload
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="hidden"
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -24,3 +24,4 @@ export * from './checkbox';
 export * from './radio-group';
 export * from './slider';
 export * from './select';
+export { default as AvatarUpload } from './avatar-upload';


### PR DESCRIPTION
## Summary
- style signup profile page with brand card layout
- unify profile form buttons and update save button gradient
- remove unused avatar logic from signup page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a29ec7f1c8324b168af754b595dd4