### PR TITLE
Align profile form with landing styles

### DIFF
--- a/src/components/UserProfileForm/Section.module.css
+++ b/src/components/UserProfileForm/Section.module.css
@@ -1,9 +1,9 @@
 /* Section.module.css */
 .card {
-  @apply bg-background p-6 rounded-lg;
+  @apply p-8 rounded-lg border border-muted bg-white/90 dark:bg-white/10 shadow-xl;
 }
 .title {
-  @apply text-xl font-semibold mb-4 text-foreground;
+  @apply text-2xl font-semibold mb-4 text-foreground;
 }
 .list {
   @apply grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4;

--- a/src/components/UserProfileForm/index.tsx
+++ b/src/components/UserProfileForm/index.tsx
@@ -39,7 +39,7 @@ export default function UserProfileForm({
         e.preventDefault();
         handleSave();
       }}
-      className="bg-background p-6 rounded-lg shadow-lg space-y-6"
+      className="space-y-6 p-8 bg-white/90 dark:bg-white/10 rounded-lg border border-muted shadow-xl"
     >
       <div className="flex justify-between items-center border-b border-accent pb-4">
         <h2 className="text-3xl font-bold text-foreground">Your Profile</h2>
@@ -47,10 +47,10 @@ export default function UserProfileForm({
           <Button
             type="button"
             onClick={toggleEditing}
-            className={`px-4 py-2 rounded font-medium text-foreground ${
+            className={`px-4 py-2 rounded font-medium ${
               editing
-                ? "bg-accent hover:bg-accent/80"
-                : "bg-primary hover:bg-primary/80"
+                ? "bg-accent text-foreground hover:bg-accent/80"
+                : "bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] text-white border-0 hover:from-[var(--brand-from)]/90 hover:to-[var(--brand-to)]/90"
             }`}
           >
             {editing ? "Cancel" : "Edit"}


### PR DESCRIPTION
## Summary
- match UserProfileForm sections to gradient card style from landing page
- use brand gradient button for editing state

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a2e0b362883249df575b730043284