### PR TITLE
Fix layout of signup profile page

### DIFF
--- a/src/app/(auth)/signup/profile/page.tsx
+++ b/src/app/(auth)/signup/profile/page.tsx
@@ -47,7 +47,7 @@ export default function OnboardingProfile() {
       <section className="relative py-20 overflow-hidden flex items-center justify-center">
         <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" />
         <div className="relative w-full px-4 sm:px-6 lg:px-8 flex justify-center">
-          <Card className="w-full max-w-2xl p-8 bg-white/90 dark:bg-white/10 shadow-xl space-y-6">
+          <Card className="w-full max-w-2xl p-8 bg-background border border-muted shadow-xl space-y-6">
             <h1 className="text-3xl font-bold text-center">
               Almost done—tell us about your running!
             </h1>

--- a/src/components/UserProfileForm/Section.module.css
+++ b/src/components/UserProfileForm/Section.module.css
@@ -1,9 +1,9 @@
 /* Section.module.css */
 .card {
-  @apply p-8 rounded-lg border border-muted bg-white/90 dark:bg-white/10 shadow-xl;
+  @apply space-y-4;
 }
 .title {
-  @apply text-2xl font-semibold mb-4 text-foreground;
+  @apply text-xl font-semibold mb-2 text-foreground;
 }
 .list {
   @apply grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4;

--- a/src/components/UserProfileForm/index.tsx
+++ b/src/components/UserProfileForm/index.tsx
@@ -39,7 +39,7 @@ export default function UserProfileForm({
         e.preventDefault();
         handleSave();
       }}
-      className="space-y-6 p-8 bg-white/90 dark:bg-white/10 rounded-lg border border-muted shadow-xl"
+      className="space-y-6"
     >
       <div className="flex justify-between items-center border-b border-accent pb-4">
         <h2 className="text-3xl font-bold text-foreground">Your Profile</h2>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-muted bg-white dark:bg-[#1e293b] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-from)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-accent-2 bg-accent-2/10 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- refactor profile form section styles
- use global colors for inputs
- simplify profile form container
- adjust signup profile page card background

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a3120da10832486d22bc9f637fa99