### PR TITLE
Implement lucide default avatars

### DIFF
--- a/src/components/DefaultAvatar.tsx
+++ b/src/components/DefaultAvatar.tsx
@@ -1,0 +1,26 @@
+import { Bike, Dumbbell, Apple, Heart, Mountain, Footprints } from "lucide-react";
+import React from "react";
+
+const icons = [Bike, Dumbbell, Apple, Heart, Mountain, Footprints];
+
+export interface DefaultAvatarProps {
+  /** Seed value to deterministically pick an icon */
+  seed?: string;
+  /** Size of the avatar circle */
+  size?: number;
+  className?: string;
+}
+
+export default function DefaultAvatar({ seed = "", size = 32, className = "" }: DefaultAvatarProps) {
+  const index = Array.from(seed).reduce((sum, ch) => sum + ch.charCodeAt(0), 0) % icons.length;
+  const IconComp = icons[index];
+  const iconSize = Math.floor(size * 0.6);
+  return (
+    <div
+      className={`flex items-center justify-center rounded-full bg-muted text-muted-foreground ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <IconComp size={iconSize} />
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { useState } from "react";
 import { Menu } from "lucide-react";
+import DefaultAvatar from "@components/DefaultAvatar";
 import { Sheet, SheetContent, SheetTrigger } from "@components/ui";
 import ModeToggle from "@components/ModeToggle";
 
@@ -77,13 +78,20 @@ export default function Navbar() {
                   aria-expanded={desktopMenuOpen}
                   className="focus:outline-none bg-transparent p-0 hover:bg-transparent focus:ring-0"
                 >
-                  <Image
-                    src={session.user.avatarUrl ?? "/Default_pfp.svg"}
-                    alt="avatar"
-                    width={32}
-                    height={32}
-                    className="w-8 h-8 rounded-full object-cover"
-                  />
+                  {session.user.avatarUrl ? (
+                    <Image
+                      src={session.user.avatarUrl}
+                      alt="avatar"
+                      width={32}
+                      height={32}
+                      className="w-8 h-8 rounded-full object-cover"
+                    />
+                  ) : (
+                    <DefaultAvatar
+                      seed={session.user.id || session.user.email || ""}
+                      size={32}
+                    />
+                  )}
                 </button>
                 {desktopMenuOpen && (
                   <div className="absolute right-0 mt-2 w-40 bg-background border border-accent/20 rounded shadow-md">
@@ -132,14 +140,20 @@ export default function Navbar() {
                 className="focus:outline-none"
               >
                 <div className="w-8 h-8 rounded-full overflow-hidden">
-                  {" "}
-                  <Image
-                    src={session.user.avatarUrl ?? "/Default_pfp.svg"}
-                    alt="avatar"
-                    width={24}
-                    height={24}
-                    className="object-cover"
-                  />
+                  {session.user.avatarUrl ? (
+                    <Image
+                      src={session.user.avatarUrl}
+                      alt="avatar"
+                      width={24}
+                      height={24}
+                      className="object-cover"
+                    />
+                  ) : (
+                    <DefaultAvatar
+                      seed={session.user.id || session.user.email || ""}
+                      size={32}
+                    />
+                  )}
                 </div>
               </button>
               {mobileMenuOpen && (

--- a/src/components/UserProfileForm/BasicInfoSection.tsx
+++ b/src/components/UserProfileForm/BasicInfoSection.tsx
@@ -3,6 +3,7 @@ import { UserProfile } from "@maratypes/user";
 import styles from "./Section.module.css";
 import type { Gender } from "@maratypes/user";
 import Image from "next/image";
+import DefaultAvatar from "@components/DefaultAvatar";
 
 // runtime list of gender options
 const genderValues: Gender[] = ["Male", "Female", "Other"];
@@ -96,13 +97,21 @@ export default function BasicInfoSection({
       ) : (
         <dl className={`${styles.list} flex flex-col gap-4`}>
           <div className="md:col-span-2 flex items-center mb-4">
-            <Image
-              src={formData.avatarUrl || "/Default_pfp.svg"}
-              alt="Avatar"
-              width={80}
-              height={80}
-              className="w-20 h-20 rounded-full object-cover"
-            />
+            {formData.avatarUrl ? (
+              <Image
+                src={formData.avatarUrl}
+                alt="Avatar"
+                width={80}
+                height={80}
+                className="w-20 h-20 rounded-full object-cover"
+              />
+            ) : (
+              <DefaultAvatar
+                seed={formData.email || formData.name || ""}
+                size={80}
+                className="w-20 h-20"
+              />
+            )}
           </div>
           <div>
             <dt className={styles.label}>Name</dt>

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { Avatar, AvatarImage, AvatarFallback, Button } from "@components/ui";
 import { uploadAvatar } from "@lib/api/user/user";
+import DefaultAvatar from "@components/DefaultAvatar";
 
 interface AvatarUploadProps {
   value?: string;
@@ -21,8 +22,10 @@ export default function AvatarUpload({ value, onChange, disabled }: AvatarUpload
   return (
     <div className="flex items-center space-x-4">
       <Avatar className="h-20 w-20">
-        <AvatarImage src={value || "/Default_pfp.svg"} alt="Avatar preview" />
-        <AvatarFallback>?</AvatarFallback>
+        {value && <AvatarImage src={value} alt="Avatar preview" />}
+        <AvatarFallback>
+          <DefaultAvatar seed="upload" size={80} className="w-full h-full" />
+        </AvatarFallback>
       </Avatar>
       <div>
         <Button


### PR DESCRIPTION
## Summary
- use lucide icons for default avatars
- show random icon based on user info
- update profile forms and navbar to use the new default avatar

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a3b6b571c832483c01d693cf727cb