### PR TITLE
Add race date field to plan generator

### DIFF
--- a/src/components/PlanGenerator.tsx
+++ b/src/components/PlanGenerator.tsx
@@ -116,7 +116,13 @@ const [targetDistance, setTargetDistance] = useState<number>(
         plan = generateClassicMarathonPlan(opts);
         break;
     }
-    setPlanData(plan);
+    if (endDate) {
+      const withDates = assignDatesToPlan(plan, { endDate });
+      setPlanData(withDates);
+      setStartDate(withDates.startDate?.slice(0, 10) ?? "");
+    } else {
+      setPlanData(plan);
+    }
   };
 
   return (
@@ -139,6 +145,19 @@ const [targetDistance, setTargetDistance] = useState<number>(
               min={8}
               value={weeks}
               onChange={(e) => setWeeks(Number(e.target.value))}
+              className="border p-2 rounded"
+            />
+          </div>
+          {/* Race Date */}
+          <div className="flex flex-col">
+            <label htmlFor="raceDate" className="mb-1">
+              Race Date:
+            </label>
+            <input
+              id="raceDate"
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
               className="border p-2 rounded"
             />
           </div>

--- a/src/components/RunningPlanDisplay.tsx
+++ b/src/components/RunningPlanDisplay.tsx
@@ -97,6 +97,8 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
           {weekPlan.phase && ` – ${weekPlan.phase} phase`} - Total Mileage:
           {" "}
           {weekPlan.weeklyMileage} {weekPlan.unit}
+          {weekPlan.runs.length === 1 && weekPlan.runs[0].type === "marathon" &&
+            " – Marathon Week"}
           {isWeekComplete ? " (Complete)" : ""}
         </h3>
         <span className="text-2xl">{isOpen ? "−" : "+"}</span>

--- a/src/lib/utils/__tests__/longDistancePlan.test.ts
+++ b/src/lib/utils/__tests__/longDistancePlan.test.ts
@@ -27,7 +27,8 @@ describe("generateLongDistancePlan cutback weeks", () => {
       26.2
     );
     const lastWeek = plan.schedule[weeks - 1];
-    const lastRun = lastWeek.runs[lastWeek.runs.length - 1];
+    expect(lastWeek.runs).toHaveLength(1);
+    const lastRun = lastWeek.runs[0];
     expect(lastRun.type).toBe("marathon");
     expect(lastWeek.notes).toBe("Race week");
   });

--- a/src/lib/utils/running/plans/longDistancePlan.ts
+++ b/src/lib/utils/running/plans/longDistancePlan.ts
@@ -278,40 +278,45 @@ export function generateLongDistancePlan(
       zones.tempo
     }) for ${tempoMileage} ${distanceUnit}, plus ${WUCD_PERCENT * 100}% WU/CD`;
 
-    const runs: PlannedRun[] = [
-      {
-        type: "easy",
-        unit: distanceUnit,
-        mileage: easyMileage,
-        targetPace: { unit: distanceUnit, pace: zones.easy },
-      },
-      {
-        type: "interval",
-        unit: distanceUnit,
-        mileage: intervalMileage,
-        targetPace: { unit: distanceUnit, pace: zones.interval },
-        notes: intervalNotes,
-      },
-      {
-        type: "tempo",
-        unit: distanceUnit,
-        mileage: tempoMileage,
-        targetPace: { unit: distanceUnit, pace: formatPace(tempoSecNum) },
-        notes: tempoNotes,
-      },
-      {
-        type: "long",
-        unit: distanceUnit,
-        mileage: roundToHalf(longDist),
-        targetPace: { unit: distanceUnit, pace: zones.marathon },
-      },
-    ];
+    let runs: PlannedRun[];
     if (week === weeks) {
-      runs[runs.length - 1] = {
-        ...runs[runs.length - 1],
-        type: "marathon",
-        mileage: roundToHalf(targetDistance),
-      };
+      runs = [
+        {
+          type: "marathon",
+          unit: distanceUnit,
+          mileage: roundToHalf(targetDistance),
+          targetPace: { unit: distanceUnit, pace: zones.marathon },
+        },
+      ];
+    } else {
+      runs = [
+        {
+          type: "easy",
+          unit: distanceUnit,
+          mileage: easyMileage,
+          targetPace: { unit: distanceUnit, pace: zones.easy },
+        },
+        {
+          type: "interval",
+          unit: distanceUnit,
+          mileage: intervalMileage,
+          targetPace: { unit: distanceUnit, pace: zones.interval },
+          notes: intervalNotes,
+        },
+        {
+          type: "tempo",
+          unit: distanceUnit,
+          mileage: tempoMileage,
+          targetPace: { unit: distanceUnit, pace: formatPace(tempoSecNum) },
+          notes: tempoNotes,
+        },
+        {
+          type: "long",
+          unit: distanceUnit,
+          mileage: roundToHalf(longDist),
+          targetPace: { unit: distanceUnit, pace: zones.marathon },
+        },
+      ];
     }
 
     const weeklyMileage = roundToHalf(runs.reduce((tot, r) => tot + r.mileage, 0));


### PR DESCRIPTION
## Summary
- allow race date entry before generating a plan
- preassign schedule dates when race date is provided
- keep start date editable after generation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a3f6cc73483249ba44f9e772eb627