### PR TITLE
Add social feed models and basic pages

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,8 @@ model User {
   runningPlans                 RunningPlan[]
   shoes                        Shoe[]    @relation("UserShoes")
 
+  profile                      UserProfile?
+
   // Default shoe relation
   defaultShoeId                String?   @unique
   defaultShoe                  Shoe?     @relation("UserDefaultShoe", fields: [defaultShoeId], references: [id])
@@ -158,4 +160,71 @@ model RunningPlan {
   user      User     @relation(fields: [userId], references: [id])
 
   @@map("RunningPlans")
+}
+
+model UserProfile {
+  id          String   @id @default(uuid())
+  userId      String   @unique
+  username    String   @unique
+  bio         String?
+  profilePhoto String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user        User     @relation(fields: [userId], references: [id])
+  posts       RunPost[]
+  following   Follow[] @relation("following")
+  followers   Follow[] @relation("followers")
+  comments    Comment[]
+  likes       Like[]
+}
+
+model RunPost {
+  id            String     @id @default(uuid())
+  userProfileId String
+  distance      Float
+  time          String
+  caption       String?
+  photoUrl      String?
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+
+  userProfile   UserProfile @relation(fields: [userProfileId], references: [id])
+  comments      Comment[]
+  likes         Like[]
+}
+
+model Follow {
+  id           String   @id @default(uuid())
+  followerId   String
+  followingId  String
+  createdAt    DateTime @default(now())
+
+  follower     UserProfile @relation("following", fields: [followerId], references: [id])
+  following    UserProfile @relation("followers", fields: [followingId], references: [id])
+
+  @@unique([followerId, followingId])
+}
+
+model Comment {
+  id            String   @id @default(uuid())
+  postId        String
+  userProfileId String
+  text          String
+  createdAt     DateTime @default(now())
+
+  post          RunPost     @relation(fields: [postId], references: [id])
+  userProfile   UserProfile @relation(fields: [userProfileId], references: [id])
+}
+
+model Like {
+  id            String   @id @default(uuid())
+  postId        String
+  userProfileId String
+  createdAt     DateTime @default(now())
+
+  post          RunPost     @relation(fields: [postId], references: [id])
+  userProfile   UserProfile @relation(fields: [userProfileId], references: [id])
+
+  @@unique([postId, userProfileId])
 }

--- a/src/app/api/social/feed/route.ts
+++ b/src/app/api/social/feed/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const userId = req.nextUrl.searchParams.get("userId");
+  if (!userId) {
+    return NextResponse.json({ error: "userId required" }, { status: 400 });
+  }
+  try {
+    const followed = await prisma.follow.findMany({
+      where: { follower: { userId } },
+      select: { followingId: true },
+    });
+    const ids = followed.map((f) => f.followingId);
+    const posts = await prisma.runPost.findMany({
+      where: { userProfileId: { in: ids } },
+      include: { userProfile: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return NextResponse.json(posts);
+  } catch (err) {
+    console.error("Error fetching feed", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/follow/route.ts
+++ b/src/app/api/social/follow/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function POST(req: NextRequest) {
+  const { followerId, followingId } = await req.json();
+  if (!followerId || !followingId) {
+    return NextResponse.json({ error: "followerId and followingId required" }, { status: 400 });
+  }
+  try {
+    const follow = await prisma.follow.upsert({
+      where: { followerId_followingId: { followerId, followingId } },
+      update: {},
+      create: { followerId, followingId },
+    });
+    return NextResponse.json(follow, { status: 201 });
+  } catch (err) {
+    console.error("Error following", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const { followerId, followingId } = await req.json();
+  try {
+    await prisma.follow.delete({
+      where: { followerId_followingId: { followerId, followingId } },
+    });
+    return NextResponse.json({});
+  } catch (err) {
+    console.error("Error unfollow", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/posts/[id]/comments/route.ts
+++ b/src/app/api/social/posts/[id]/comments/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function POST(req: NextRequest, ctx: { params: { id: string } }) {
+  const { userProfileId, text } = await req.json();
+  const { id } = ctx.params;
+  try {
+    const comment = await prisma.comment.create({
+      data: { postId: id, userProfileId, text },
+    });
+    return NextResponse.json(comment, { status: 201 });
+  } catch (err) {
+    console.error("Error commenting", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
+  try {
+    const comments = await prisma.comment.findMany({
+      where: { postId: id },
+      include: { userProfile: true },
+      orderBy: { createdAt: "asc" },
+    });
+    return NextResponse.json(comments);
+  } catch (err) {
+    console.error("Error listing comments", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/posts/[id]/like/route.ts
+++ b/src/app/api/social/posts/[id]/like/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function POST(req: NextRequest, ctx: { params: { id: string } }) {
+  const { userProfileId } = await req.json();
+  const { id } = ctx.params;
+  try {
+    const like = await prisma.like.upsert({
+      where: { postId_userProfileId: { postId: id, userProfileId } },
+      update: {},
+      create: { postId: id, userProfileId },
+    });
+    return NextResponse.json(like, { status: 201 });
+  } catch (err) {
+    console.error("Error liking", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, ctx: { params: { id: string } }) {
+  const { userProfileId } = await req.json();
+  const { id } = ctx.params;
+  try {
+    await prisma.like.delete({
+      where: { postId_userProfileId: { postId: id, userProfileId } },
+    });
+    return NextResponse.json({});
+  } catch (err) {
+    console.error("Error unliking", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/posts/[id]/route.ts
+++ b/src/app/api/social/posts/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(_req: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
+  try {
+    const post = await prisma.runPost.findUnique({
+      where: { id },
+      include: { userProfile: true, comments: true, likes: true },
+    });
+    if (!post) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(post);
+  } catch (err) {
+    console.error("Error getting post", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function PUT(req: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
+  try {
+    const data = await req.json();
+    const post = await prisma.runPost.update({ where: { id }, data });
+    return NextResponse.json(post);
+  } catch (err) {
+    console.error("Error updating post", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
+  try {
+    await prisma.runPost.delete({ where: { id } });
+    return NextResponse.json({});
+  } catch (err) {
+    console.error("Error deleting post", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/posts/route.ts
+++ b/src/app/api/social/posts/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET() {
+  try {
+    const posts = await prisma.runPost.findMany({
+      include: { userProfile: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return NextResponse.json(posts);
+  } catch (err) {
+    console.error("Error listing posts", err);
+    return NextResponse.json({ error: "Failed to fetch posts" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    const post = await prisma.runPost.create({ data });
+    return NextResponse.json(post, { status: 201 });
+  } catch (err) {
+    console.error("Error creating post", err);
+    return NextResponse.json({ error: "Failed to create post" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/profile/[username]/route.ts
+++ b/src/app/api/social/profile/[username]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(_req: NextRequest, ctx: { params: { username: string } }) {
+  const { username } = ctx.params;
+  try {
+    const profile = await prisma.userProfile.findUnique({
+      where: { username },
+      include: {
+        user: {
+          select: {
+            name: true,
+            _count: { select: { runs: true } },
+          },
+        },
+        _count: { select: { followers: true, following: true } },
+      },
+    });
+    if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const data = {
+      id: profile.id,
+      userId: profile.userId,
+      username: profile.username,
+      bio: profile.bio,
+      profilePhoto: profile.profilePhoto,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+      name: profile.user.name,
+      runCount: profile.user._count.runs,
+      followerCount: profile._count.followers,
+      followingCount: profile._count.following,
+    };
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error("Error getting profile", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/social/feed/page.tsx
+++ b/src/app/social/feed/page.tsx
@@ -1,0 +1,10 @@
+import SocialFeed from "@components/SocialFeed";
+
+export default function FeedPage() {
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+      <h1 className="text-2xl font-bold mb-4">Your Feed</h1>
+      <SocialFeed />
+    </div>
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import type { SocialUserProfile } from "@maratypes/social";
+
+async function getProfile(username: string): Promise<SocialUserProfile | null> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/social/profile/${username}`);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+interface Props {
+  params: { username: string };
+}
+
+export default async function UserProfilePage({ params }: Props) {
+  const profile = await getProfile(params.username);
+  if (!profile) return notFound();
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6 space-y-4">
+      <div className="flex items-center gap-4">
+        {profile.profilePhoto && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={profile.profilePhoto}
+            alt={profile.username}
+            className="w-16 h-16 rounded-full object-cover"
+          />
+        )}
+        <div>
+          <h1 className="text-2xl font-bold">{profile.name ?? profile.username}</h1>
+          {profile.bio && <p className="text-foreground/70">{profile.bio}</p>}
+        </div>
+      </div>
+      <div className="flex gap-4 text-foreground/80">
+        <span>{profile.runCount ?? 0} runs</span>
+        <span>{profile.followerCount ?? 0} followers</span>
+        <span>{profile.followingCount ?? 0} following</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SocialFeed.tsx
+++ b/src/components/SocialFeed.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import type { RunPost } from "@maratypes/social";
+import { useSession } from "next-auth/react";
+
+export default function SocialFeed() {
+  const { data: session } = useSession();
+  const [posts, setPosts] = useState<RunPost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFeed = async () => {
+      if (!session?.user?.id) return;
+      try {
+        const { data } = await axios.get<RunPost[]>(
+          `/api/social/feed?userId=${session.user.id}`
+        );
+        setPosts(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFeed();
+  }, [session?.user?.id]);
+
+  if (!session?.user?.id) return <p>Please log in to view your feed.</p>;
+  if (loading) return <p className="text-foreground/60">Loading feed...</p>;
+  if (posts.length === 0) return <p>No posts yet.</p>;
+
+  return (
+    <div className="space-y-6">
+      {posts.map((post) => (
+        <div key={post.id} className="border rounded-md p-4">
+          <div className="flex items-center gap-2 mb-2">
+            {post.userProfile?.profilePhoto && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={post.userProfile.profilePhoto}
+                alt={post.userProfile.username}
+                className="w-8 h-8 rounded-full object-cover"
+              />
+            )}
+            <span className="font-semibold">
+              {post.userProfile?.username}
+            </span>
+          </div>
+          <p className="font-medium">
+            {post.distance} mi in {post.time}
+          </p>
+          {post.caption && <p className="mt-2">{post.caption}</p>}
+          {post.photoUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={post.photoUrl}
+              alt="Run photo"
+              className="mt-2 rounded-md"
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -1,0 +1,50 @@
+export interface SocialUserProfile {
+  id: string;
+  userId: string;
+  username: string;
+  bio?: string;
+  profilePhoto?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  name?: string;
+  runCount?: number;
+  followerCount?: number;
+  followingCount?: number;
+}
+
+export interface RunPost {
+  id: string;
+  userProfileId: string;
+  distance: number;
+  time: string;
+  caption?: string;
+  photoUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userProfile?: SocialUserProfile;
+  likeCount?: number;
+  commentCount?: number;
+}
+
+export interface Follow {
+  id: string;
+  followerId: string;
+  followingId: string;
+  createdAt: Date;
+}
+
+export interface Comment {
+  id: string;
+  postId: string;
+  userProfileId: string;
+  text: string;
+  createdAt: Date;
+  userProfile?: SocialUserProfile;
+}
+
+export interface Like {
+  id: string;
+  postId: string;
+  userProfileId: string;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- define social models in Prisma
- implement API routes for run posts, follows, feed and profile lookup
- create SocialFeed component and related pages
- add types for social features
- enrich profile route with counts and show them on profile page

## Testing
- `npm run lint`
- `npm test`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_684a475b4f6083248ca11f9bd9225c10