### PR TITLE
Add social profile search and stats

### DIFF
--- a/src/app/api/social/profile/byUser/[id]/route.ts
+++ b/src/app/api/social/profile/byUser/[id]/route.ts
@@ -1,17 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
 
-export async function GET(_req: NextRequest, ctx: { params: { username: string } }) {
-  const { username } = ctx.params;
+export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
   try {
     const profile = await prisma.userProfile.findUnique({
-      where: { username },
+      where: { userId: id },
       include: {
         user: {
-          select: {
-            name: true,
-            _count: { select: { runs: true } },
-          },
+          select: { name: true, _count: { select: { runs: true } } },
         },
         _count: { select: { followers: true, following: true } },
       },
@@ -19,7 +16,7 @@ export async function GET(_req: NextRequest, ctx: { params: { username: string }
     if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
     const total = await prisma.run.aggregate({
-      where: { userId: profile.userId },
+      where: { userId: id },
       _sum: { distance: true },
     });
 

--- a/src/app/api/social/search/route.ts
+++ b/src/app/api/social/search/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get("q") || "";
+  if (!q) return NextResponse.json([]);
+  try {
+    const profiles = await prisma.userProfile.findMany({
+      where: {
+        OR: [
+          { username: { contains: q, mode: "insensitive" } },
+          { user: { name: { contains: q, mode: "insensitive" } } },
+        ],
+      },
+      include: {
+        user: { select: { name: true, _count: { select: { runs: true } } } },
+        _count: { select: { followers: true, following: true } },
+      },
+      take: 10,
+    });
+
+    const results = await Promise.all(
+      profiles.map(async (p) => {
+        const total = await prisma.run.aggregate({
+          where: { userId: p.userId },
+          _sum: { distance: true },
+        });
+        return {
+          id: p.id,
+          userId: p.userId,
+          username: p.username,
+          bio: p.bio,
+          profilePhoto: p.profilePhoto,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+          name: p.user.name,
+          runCount: p.user._count.runs,
+          totalDistance: total._sum.distance ?? 0,
+          followerCount: p._count.followers,
+          followingCount: p._count.following,
+        };
+      })
+    );
+
+    return NextResponse.json(results);
+  } catch (err) {
+    console.error("Error searching profiles", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/social/search/page.tsx
+++ b/src/app/social/search/page.tsx
@@ -1,0 +1,10 @@
+import ProfileSearch from "@components/ProfileSearch";
+
+export default function SearchPage() {
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+      <h1 className="text-2xl font-bold mb-4">Find Runners</h1>
+      <ProfileSearch />
+    </div>
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -33,6 +33,7 @@ export default async function UserProfilePage({ params }: Props) {
       </div>
       <div className="flex gap-4 text-foreground/80">
         <span>{profile.runCount ?? 0} runs</span>
+        <span>{profile.totalDistance ?? 0} mi total</span>
         <span>{profile.followerCount ?? 0} followers</span>
         <span>{profile.followingCount ?? 0} following</span>
       </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,6 +19,7 @@ export default function Navbar() {
     { href: "/runs/new", label: "Add Run" },
     { href: "/shoes/new", label: "Add Shoe" },
     { href: "/plan-generator", label: "Plans" },
+    { href: "/social/feed", label: "Social" },
     { href: "/about", label: "About" },
   ];
 

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -8,6 +8,7 @@ export interface SocialUserProfile {
   updatedAt: Date;
   name?: string;
   runCount?: number;
+  totalDistance?: number;
   followerCount?: number;
   followingCount?: number;
 }


### PR DESCRIPTION
## Summary
- extend social profile model with `totalDistance`
- expose total distance in social profile API
- implement search API and page for social profiles
- include follow button for results
- add 'Social' link in Navbar
- show total mileage on profile page

## Testing
- `npx next lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a4b4f7ac88324a6d94f379eaf2ada