### PR TITLE
Add social profile creation UI and posting

### DIFF
--- a/src/app/api/social/profile/route.ts
+++ b/src/app/api/social/profile/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function POST(req: NextRequest) {
+  const { userId, username, bio, profilePhoto } = await req.json();
+  if (!userId || !username) {
+    return NextResponse.json(
+      { error: "userId and username required" },
+      { status: 400 }
+    );
+  }
+  try {
+    const profile = await prisma.userProfile.create({
+      data: { userId, username, bio, profilePhoto },
+    });
+    return NextResponse.json(profile, { status: 201 });
+  } catch (err) {
+    console.error("Error creating profile", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/social/profile/new/page.tsx
+++ b/src/app/social/profile/new/page.tsx
@@ -1,0 +1,9 @@
+import SocialProfileForm from "@components/SocialProfileForm";
+
+export default function NewSocialProfilePage() {
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6 flex justify-center">
+      <SocialProfileForm />
+    </div>
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import type { SocialUserProfile } from "@maratypes/social";
+import FollowUserButton from "@components/FollowUserButton";
 
 async function getProfile(username: string): Promise<SocialUserProfile | null> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/social/profile/${username}`);
@@ -37,6 +38,7 @@ export default async function UserProfilePage({ params }: Props) {
         <span>{profile.followerCount ?? 0} followers</span>
         <span>{profile.followingCount ?? 0} following</span>
       </div>
+      <FollowUserButton profileId={profile.id} />
     </div>
   );
 }

--- a/src/components/CreateSocialPost.tsx
+++ b/src/components/CreateSocialPost.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useState, FormEvent } from "react";
+import { createPost } from "@lib/api/social";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+import { Card, Button } from "@components/ui";
+import { TextField, TextAreaField } from "@components/ui/FormField";
+
+interface Props {
+  onCreated?: () => void;
+}
+
+export default function CreateSocialPost({ onCreated }: Props) {
+  const { profile } = useSocialProfile();
+  const [distance, setDistance] = useState("");
+  const [time, setTime] = useState("");
+  const [caption, setCaption] = useState("");
+  const [photoUrl, setPhotoUrl] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  if (!profile) return null;
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    if (!distance || !time) {
+      setError("Distance and time required");
+      return;
+    }
+    try {
+      await createPost({
+        userProfileId: profile.id,
+        distance: parseFloat(distance),
+        time,
+        caption: caption || undefined,
+        photoUrl: photoUrl || undefined,
+      });
+      setSuccess("Posted!");
+      setDistance("");
+      setTime("");
+      setCaption("");
+      setPhotoUrl("");
+      onCreated?.();
+    } catch {
+      setError("Failed to create post");
+    }
+  };
+
+  return (
+    <Card className="p-4 mb-6">
+      <h3 className="text-lg font-semibold mb-2">Share a Run</h3>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      {success && <p className="text-primary mb-2">{success}</p>}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <TextField
+          label="Distance (mi)"
+          name="distance"
+          type="number"
+          value={distance}
+          onChange={(_n, v) => setDistance(String(v))}
+          required
+        />
+        <TextField
+          label="Time (HH:MM:SS)"
+          name="time"
+          value={time}
+          onChange={(_n, v) => setTime(String(v))}
+          required
+        />
+        <TextAreaField
+          label="Caption"
+          name="caption"
+          value={caption}
+          onChange={(_n, v) => setCaption(String(v))}
+          rows={2}
+        />
+        <TextField
+          label="Photo URL"
+          name="photoUrl"
+          value={photoUrl}
+          onChange={(_n, v) => setPhotoUrl(String(v))}
+        />
+        <div className="flex justify-end">
+          <Button type="submit" size="sm">
+            Post
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/FollowUserButton.tsx
+++ b/src/components/FollowUserButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+import { followUser } from "@lib/api/social";
+import { Button } from "@components/ui";
+
+interface Props {
+  profileId: string;
+}
+
+export default function FollowUserButton({ profileId }: Props) {
+  const { data: session } = useSession();
+  const { profile } = useSocialProfile();
+  const [done, setDone] = useState(false);
+
+  if (!session?.user || !profile || profile.id === profileId) return null;
+
+  const onFollow = async () => {
+    try {
+      await followUser(profile.id, profileId);
+      setDone(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Button onClick={onFollow} size="sm" disabled={done} className="mt-2">
+      {done ? "Following" : "Follow"}
+    </Button>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -20,6 +20,7 @@ export default function Navbar() {
     { href: "/shoes/new", label: "Add Shoe" },
     { href: "/plan-generator", label: "Plans" },
     { href: "/social/feed", label: "Social" },
+    { href: "/social/search", label: "Find Runners" },
     { href: "/about", label: "About" },
   ];
 

--- a/src/components/ProfileSearch.tsx
+++ b/src/components/ProfileSearch.tsx
@@ -10,6 +10,7 @@ export default function ProfileSearch() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SocialUserProfile[]>([]);
   const [myProfileId, setMyProfileId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchMyProfile = async () => {
@@ -19,9 +20,13 @@ export default function ProfileSearch() {
             `/api/social/profile/byUser/${session.user.id}`
           );
           setMyProfileId(data.id);
-        } catch (err) {
-          console.error(err);
+        } catch {
+          setMyProfileId(null);
+        } finally {
+          setLoading(false);
         }
+      } else {
+        setLoading(false);
       }
     };
     fetchMyProfile();
@@ -50,6 +55,18 @@ export default function ProfileSearch() {
       console.error(err);
     }
   };
+
+  if (!session?.user?.id) return <p>Please log in to search.</p>;
+  if (loading) return <p className="text-foreground/60">Loading...</p>;
+  if (!myProfileId)
+    return (
+      <div className="space-y-2">
+        <p>Create your social profile first.</p>
+        <Button asChild>
+          <a href="/social/profile/new">Create Social Profile</a>
+        </Button>
+      </div>
+    );
 
   return (
     <div>

--- a/src/components/SocialProfileForm.tsx
+++ b/src/components/SocialProfileForm.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { useSession } from "next-auth/react";
+import { createSocialProfile } from "@lib/api/social";
+import { Card, Button } from "@components/ui";
+import { TextField, TextAreaField } from "@components/ui/FormField";
+
+interface Props {
+  onCreated?: () => void;
+}
+
+export default function SocialProfileForm({ onCreated }: Props) {
+  const { data: session } = useSession();
+  const [username, setUsername] = useState("");
+  const [bio, setBio] = useState("");
+  const [profilePhoto, setProfilePhoto] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+
+    if (!session?.user?.id || !username) {
+      setError("Username required");
+      return;
+    }
+
+    try {
+      await createSocialProfile({
+        userId: session.user.id,
+        username,
+        bio: bio || undefined,
+        profilePhoto: profilePhoto || undefined,
+      });
+      setSuccess("Profile created!");
+      setUsername("");
+      setBio("");
+      setProfilePhoto("");
+      onCreated?.();
+    } catch {
+      setError("Failed to create profile");
+    }
+  };
+
+  return (
+    <Card className="p-6 w-full max-w-md">
+      <h2 className="text-2xl font-semibold mb-4">Create Social Profile</h2>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      {success && <p className="text-primary mb-2">{success}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          label="Username"
+          name="username"
+          value={username}
+          onChange={(_n, v) => setUsername(String(v))}
+          required
+        />
+        <TextAreaField
+          label="Bio"
+          name="bio"
+          value={bio}
+          onChange={(_n, v) => setBio(String(v))}
+          rows={2}
+        />
+        <TextField
+          label="Profile Photo URL"
+          name="profilePhoto"
+          value={profilePhoto}
+          onChange={(_n, v) => setProfilePhoto(String(v))}
+        />
+        <div className="flex justify-end">
+          <Button type="submit">Create Profile</Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/hooks/useSocialProfile.ts
+++ b/src/hooks/useSocialProfile.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import axios from "axios";
+import type { SocialUserProfile } from "@maratypes/social";
+
+export function useSocialProfile() {
+  const { data: session } = useSession();
+  const [profile, setProfile] = useState<SocialUserProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      if (!session?.user?.id) {
+        setProfile(null);
+        return;
+      }
+      setLoading(true);
+      try {
+        const { data } = await axios.get<SocialUserProfile>(
+          `/api/social/profile/byUser/${session.user.id}`
+        );
+        setProfile(data);
+      } catch {
+        setProfile(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+  }, [session?.user?.id]);
+
+  return { profile, loading };
+}

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -1,0 +1,38 @@
+import axios from "axios";
+import { createSocialProfile, followUser, unfollowUser, createPost } from "../social";
+import type { RunPost } from "@maratypes/social";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("social api helpers", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("createSocialProfile posts data", async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: "p1" } });
+    const data = { userId: "u1", username: "tester" };
+    const result = await createSocialProfile(data);
+    expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/profile", data);
+    expect(result).toEqual({ id: "p1" });
+  });
+
+  it("followUser posts data", async () => {
+    mockedAxios.post.mockResolvedValue({ data: {} });
+    await followUser("a", "b");
+    expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/follow", { followerId: "a", followingId: "b" });
+  });
+
+  it("unfollowUser deletes data", async () => {
+    mockedAxios.delete.mockResolvedValue({ data: {} });
+    await unfollowUser("a", "b");
+    expect(mockedAxios.delete).toHaveBeenCalledWith("/api/social/follow", { data: { followerId: "a", followingId: "b" } });
+  });
+
+  it("createPost posts data", async () => {
+    const post: RunPost = { id: "1", userProfileId: "p", distance: 1, time: "00:10:00", createdAt: new Date(), updatedAt: new Date() } as RunPost;
+    mockedAxios.post.mockResolvedValue({ data: post });
+    const result = await createPost({ distance: 1 });
+    expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/posts", { distance: 1 });
+    expect(result).toEqual(post);
+  });
+});

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+import type { SocialUserProfile, RunPost } from "@maratypes/social";
+
+export const createSocialProfile = async (
+  data: Pick<SocialUserProfile, "userId" | "username"> & Partial<SocialUserProfile>
+): Promise<SocialUserProfile> => {
+  const { data: profile } = await axios.post<SocialUserProfile>(
+    "/api/social/profile",
+    data
+  );
+  return profile;
+};
+
+export const followUser = async (
+  followerId: string,
+  followingId: string
+): Promise<void> => {
+  await axios.post("/api/social/follow", { followerId, followingId });
+};
+
+export const unfollowUser = async (
+  followerId: string,
+  followingId: string
+): Promise<void> => {
+  await axios.delete("/api/social/follow", {
+    data: { followerId, followingId },
+  });
+};
+
+export const createPost = async (
+  data: Partial<RunPost>
+): Promise<RunPost> => {
+  const { data: post } = await axios.post<RunPost>("/api/social/posts", data);
+  return post;
+};
+


### PR DESCRIPTION
## Summary
- allow social profile creation from `/social/profile/new`
- show create post form and profile check in social feed
- enable following others from profile page and search
- add hook for fetching current social profile
- expose social search link in navbar
- decouple social profile creation from signup and prompt users on feed/search pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a4d9a0df08324a6a2a8abf2f535ea