### PR TITLE
Add tests for social React components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,9 @@ module.exports = {
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>/',
   }),
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
 };

--- a/src/components/__tests__/CreateSocialPost.test.tsx
+++ b/src/components/__tests__/CreateSocialPost.test.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreateSocialPost from "../CreateSocialPost";
+import { createPost } from "@lib/api/social";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+
+jest.mock("@lib/api/social");
+jest.mock("@hooks/useSocialProfile", () => ({ useSocialProfile: jest.fn() }));
+
+const mockedCreate = createPost as jest.MockedFunction<typeof createPost>;
+const mockedUseProfile = useSocialProfile as jest.Mock;
+
+describe("CreateSocialPost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("submits post data", async () => {
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    mockedCreate.mockResolvedValue({ id: "post1" } as any);
+    const onCreated = jest.fn();
+    const user = userEvent.setup();
+
+    render(<CreateSocialPost onCreated={onCreated} />);
+
+    await user.type(screen.getByLabelText(/distance/i), "3");
+    await user.type(screen.getByLabelText(/time/i), "00:20:00");
+    await user.type(screen.getByLabelText(/caption/i), "Nice run");
+    await user.click(screen.getByRole("button", { name: /post/i }));
+
+    expect(mockedCreate).toHaveBeenCalledWith({
+      userProfileId: "p1",
+      distance: 3,
+      time: "00:20:00",
+      caption: "Nice run",
+      photoUrl: undefined,
+    });
+    expect(onCreated).toHaveBeenCalled();
+    expect(await screen.findByText(/posted!/i)).toBeInTheDocument();
+  });
+
+  it("shows error when required fields missing", async () => {
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    render(<CreateSocialPost />);
+
+    const form = screen.getByRole("button", { name: /post/i }).closest("form")!;
+    fireEvent.submit(form);
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(await screen.findByText(/distance and time required/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/FollowUserButton.test.tsx
+++ b/src/components/__tests__/FollowUserButton.test.tsx
@@ -1,0 +1,38 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FollowUserButton from "../FollowUserButton";
+import { followUser } from "@lib/api/social";
+import { useSession } from "next-auth/react";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+
+jest.mock("@lib/api/social");
+jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
+jest.mock("@hooks/useSocialProfile", () => ({ useSocialProfile: jest.fn() }));
+
+const mockedFollow = followUser as jest.MockedFunction<typeof followUser>;
+const mockedSession = useSession as jest.Mock;
+const mockedUseProfile = useSocialProfile as jest.Mock;
+
+describe("FollowUserButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("follows another user", async () => {
+    mockedSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    mockedFollow.mockResolvedValue();
+    const user = userEvent.setup();
+
+    render(<FollowUserButton profileId="p2" />);
+
+    const btn = screen.getByRole("button", { name: /follow/i });
+    await user.click(btn);
+
+    expect(mockedFollow).toHaveBeenCalledWith("p1", "p2");
+    expect(btn).toBeDisabled();
+    expect(await screen.findByText(/following/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ProfileSearch.test.tsx
+++ b/src/components/__tests__/ProfileSearch.test.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProfileSearch from "../ProfileSearch";
+import { useSession } from "next-auth/react";
+import axios from "axios";
+
+jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
+jest.mock("axios");
+
+const mockedSession = useSession as jest.Mock;
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("ProfileSearch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requires login", () => {
+    mockedSession.mockReturnValue({ data: null });
+    render(<ProfileSearch />);
+    expect(screen.getByText(/please log in/i)).toBeInTheDocument();
+  });
+
+  it("searches profiles", async () => {
+    mockedSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.includes("/byUser/")) {
+        return Promise.resolve({ data: { id: "p1" } });
+      }
+      return Promise.resolve({ data: [{ id: "p2", username: "runner" }] });
+    });
+    const user = userEvent.setup();
+
+    render(<ProfileSearch />);
+
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledWith("/api/social/profile/byUser/u1"));
+    await waitFor(() => screen.getByPlaceholderText(/search runners/i));
+
+    await user.type(screen.getByPlaceholderText(/search runners/i), "run");
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledWith("/api/social/search?q=run"));
+    expect(await screen.findByText(/runner/)).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/SocialFeed.test.tsx
+++ b/src/components/__tests__/SocialFeed.test.tsx
@@ -1,0 +1,43 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import SocialFeed from "../SocialFeed";
+import { useSession } from "next-auth/react";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+import axios from "axios";
+
+jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
+jest.mock("@hooks/useSocialProfile", () => ({ useSocialProfile: jest.fn() }));
+jest.mock("axios");
+
+jest.mock("@components/CreateSocialPost", () => ({ __esModule: true, default: () => <div data-testid="create-post" /> }));
+
+const mockedSession = useSession as jest.Mock;
+const mockedUseProfile = useSocialProfile as jest.Mock;
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("SocialFeed", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requires login", () => {
+    mockedSession.mockReturnValue({ data: null });
+    mockedUseProfile.mockReturnValue({ profile: null, loading: false });
+    render(<SocialFeed />);
+    expect(screen.getByText(/please log in/i)).toBeInTheDocument();
+  });
+
+  it("shows posts", async () => {
+    mockedSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1" }, loading: false });
+    mockedAxios.get.mockResolvedValue({ data: [{ id: "post1", distance: 3, time: "00:20:00", userProfile: { username: "tester" } }] });
+
+    render(<SocialFeed />);
+
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledWith("/api/social/feed?userId=u1"));
+
+    expect(await screen.findByText(/tester/)).toBeInTheDocument();
+    expect(screen.getByText(/3 mi in 00:20:00/)).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/SocialProfileForm.test.tsx
+++ b/src/components/__tests__/SocialProfileForm.test.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SocialProfileForm from "../SocialProfileForm";
+import { createSocialProfile } from "@lib/api/social";
+import { useSession } from "next-auth/react";
+
+jest.mock("@lib/api/social");
+jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
+
+const mockedCreate = createSocialProfile as jest.MockedFunction<typeof createSocialProfile>;
+const mockedUseSession = useSession as jest.Mock;
+
+describe("SocialProfileForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("submits profile data", async () => {
+    mockedUseSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    mockedCreate.mockResolvedValue({ id: "p1" } as any);
+    const onCreated = jest.fn();
+    const user = userEvent.setup();
+
+    render(<SocialProfileForm onCreated={onCreated} />);
+
+    await user.type(screen.getByLabelText(/username/i), "tester");
+    await user.click(screen.getByRole("button", { name: /create profile/i }));
+
+    expect(mockedCreate).toHaveBeenCalledWith({
+      userId: "u1",
+      username: "tester",
+      bio: undefined,
+      profilePhoto: undefined,
+    });
+    expect(onCreated).toHaveBeenCalled();
+    expect(await screen.findByText(/profile created!/i)).toBeInTheDocument();
+  });
+
+  it("shows error when session missing", async () => {
+    mockedUseSession.mockReturnValue({ data: null });
+    const user = userEvent.setup();
+
+    render(<SocialProfileForm />);
+
+    await user.type(screen.getByLabelText(/username/i), "tester");
+    await user.click(screen.getByRole("button", { name: /create profile/i }));
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(await screen.findByText(/username required/i)).toBeInTheDocument();
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": false
+  }
+}


### PR DESCRIPTION
## Summary
- add tsconfig for jest with React JSX support
- configure jest to use new tsconfig
- test SocialProfileForm create flow and validation
- test CreateSocialPost form logic and validation errors
- test FollowUserButton behavior
- test SocialFeed login and posts display
- test ProfileSearch search flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a54ea249c8324a2e66811218762d4