### PR TITLE
Improve live profile search

### DIFF
--- a/src/app/api/social/search/route.ts
+++ b/src/app/api/social/search/route.ts
@@ -4,13 +4,16 @@ import { prisma } from "@lib/prisma";
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get("q") || "";
   if (!q) return NextResponse.json([]);
+  const tokens = q.split(/\s+/).filter(Boolean);
   try {
     const profiles = await prisma.userProfile.findMany({
       where: {
-        OR: [
-          { username: { contains: q, mode: "insensitive" } },
-          { user: { name: { contains: q, mode: "insensitive" } } },
-        ],
+        AND: tokens.map((t) => ({
+          OR: [
+            { username: { contains: t, mode: "insensitive" } },
+            { user: { name: { contains: t, mode: "insensitive" } } },
+          ],
+        })),
       },
       include: {
         user: { select: { name: true, _count: { select: { runs: true } } } },

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -3,17 +3,21 @@ import type { SocialUserProfile } from "@maratypes/social";
 import FollowUserButton from "@components/FollowUserButton";
 
 async function getProfile(username: string): Promise<SocialUserProfile | null> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/social/profile/${username}`);
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
+  const res = await fetch(`${baseUrl}/api/social/profile/${username}`);
   if (!res.ok) return null;
   return res.json();
 }
 
 interface Props {
-  params: { username: string };
+  params: Promise<{ username: string }>;
 }
 
 export default async function UserProfilePage({ params }: Props) {
-  const profile = await getProfile(params.username);
+  const { username } = await params;
+  const profile = await getProfile(username);
   if (!profile) return notFound();
 
   return (

--- a/src/components/ProfileSearch.tsx
+++ b/src/components/ProfileSearch.tsx
@@ -44,6 +44,24 @@ export default function ProfileSearch() {
     }
   };
 
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    const timeout = setTimeout(async () => {
+      try {
+        const { data } = await axios.get<SocialUserProfile[]>(
+          `/api/social/search?q=${encodeURIComponent(query)}`
+        );
+        setResults(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [query]);
+
   const follow = async (id: string) => {
     if (!myProfileId) return;
     try {

--- a/src/components/__tests__/ProfileSearch.test.tsx
+++ b/src/components/__tests__/ProfileSearch.test.tsx
@@ -39,9 +39,10 @@ describe("ProfileSearch", () => {
     await waitFor(() => screen.getByPlaceholderText(/search runners/i));
 
     await user.type(screen.getByPlaceholderText(/search runners/i), "run");
-    await user.click(screen.getByRole("button", { name: /search/i }));
 
-    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledWith("/api/social/search?q=run"));
+    await waitFor(() =>
+      expect(mockedAxios.get).toHaveBeenCalledWith("/api/social/search?q=run")
+    );
     expect(await screen.findByText(/runner/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- query tokens for smarter profile search results
- update search component to auto-search as you type
- adjust tests for live search behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a574841848324a03ce972e8a75f6b