### PR TITLE
Fix navbar dropdown layering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ export default function Landing() {
 
       {/* Hero Section */}
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-white/60 dark:bg-white/5 backdrop-blur-sm"></div>
+        <div className="absolute inset-0 bg-white/60 dark:bg-white/5 backdrop-blur-sm z-0"></div>
         <div className="w-full px-4 sm:px-6 lg:px-8 py-20 relative">
           <div className="w-full text-center bg-red">
             <Badge className="mb-6 bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] text-white border-0">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,7 +23,7 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="bg-white dark:bg-[#111827] border-b border-muted dark:border-white/10 backdrop-blur-sm">
+    <nav className="bg-white dark:bg-[#111827] border-b border-muted dark:border-white/10 backdrop-blur-sm relative z-20">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex items-center justify-between py-6">
         {/* Left: Logo and links */}
         <div className="flex items-center">
@@ -94,7 +94,7 @@ export default function Navbar() {
                   )}
                 </button>
                 {desktopMenuOpen && (
-                  <div className="absolute right-0 mt-2 w-40 bg-background border border-accent/20 rounded shadow-md">
+                  <div className="absolute right-0 mt-2 w-40 bg-background border border-accent/20 rounded shadow-md z-50">
                     <Link
                       href="/userProfile"
                       className="block px-4 py-2 hover:bg-accent/20"
@@ -157,7 +157,7 @@ export default function Navbar() {
                 </div>
               </button>
               {mobileMenuOpen && (
-                <div className="absolute right-0 mt-2 w-40 bg-background border border-accent/20 rounded shadow-md">
+                <div className="absolute right-0 mt-2 w-40 bg-background border border-accent/20 rounded shadow-md z-50">
                   <Link
                     href="/userProfile"
                     className="block px-4 py-2 hover:bg-accent/20"


### PR DESCRIPTION
## Summary
- ensure navbar sits above hero blur overlay
- raise z-index of profile dropdown menus

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ae6b5f7a48324a5a678b34ef15aeb