### PR TITLE
Add unfollow button

### DIFF
--- a/src/app/api/social/follow/route.ts
+++ b/src/app/api/social/follow/route.ts
@@ -19,6 +19,26 @@ export async function POST(req: NextRequest) {
   }
 }
 
+export async function GET(req: NextRequest) {
+  const followerId = req.nextUrl.searchParams.get("followerId");
+  const followingId = req.nextUrl.searchParams.get("followingId");
+  if (!followerId || !followingId) {
+    return NextResponse.json(
+      { error: "followerId and followingId required" },
+      { status: 400 }
+    );
+  }
+  try {
+    const follow = await prisma.follow.findUnique({
+      where: { followerId_followingId: { followerId, followingId } },
+    });
+    return NextResponse.json({ following: !!follow });
+  } catch (err) {
+    console.error("Error checking follow", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
 export async function DELETE(req: NextRequest) {
   const { followerId, followingId } = await req.json();
   try {

--- a/src/components/ProfileSearch.tsx
+++ b/src/components/ProfileSearch.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import { useSession } from "next-auth/react";
 import type { SocialUserProfile } from "@maratypes/social";
 import { Input, Button, Card } from "@components/ui";
+import FollowUserButton from "@components/FollowUserButton";
 
 export default function ProfileSearch() {
   const { data: session } = useSession();
@@ -62,17 +63,6 @@ export default function ProfileSearch() {
     return () => clearTimeout(timeout);
   }, [query]);
 
-  const follow = async (id: string) => {
-    if (!myProfileId) return;
-    try {
-      await axios.post("/api/social/follow", {
-        followerId: myProfileId,
-        followingId: id,
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  };
 
   if (!session?.user?.id) return <p>Please log in to search.</p>;
   if (loading) return <p className="text-foreground/60">Loading...</p>;
@@ -110,9 +100,7 @@ export default function ProfileSearch() {
               </div>
             </div>
             {myProfileId && myProfileId !== p.id && (
-              <Button onClick={() => follow(p.id)} size="sm">
-                Follow
-              </Button>
+              <FollowUserButton profileId={p.id} />
             )}
           </Card>
         ))}

--- a/src/components/__tests__/FollowUserButton.test.tsx
+++ b/src/components/__tests__/FollowUserButton.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FollowUserButton from "../FollowUserButton";
-import { followUser } from "@lib/api/social";
+import { followUser, unfollowUser, isFollowing } from "@lib/api/social";
 import { useSession } from "next-auth/react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 
@@ -12,6 +12,8 @@ jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
 jest.mock("@hooks/useSocialProfile", () => ({ useSocialProfile: jest.fn() }));
 
 const mockedFollow = followUser as jest.MockedFunction<typeof followUser>;
+const mockedUnfollow = unfollowUser as jest.MockedFunction<typeof unfollowUser>;
+const mockedIsFollowing = isFollowing as jest.MockedFunction<typeof isFollowing>;
 const mockedSession = useSession as jest.Mock;
 const mockedUseProfile = useSocialProfile as jest.Mock;
 
@@ -23,16 +25,32 @@ describe("FollowUserButton", () => {
   it("follows another user", async () => {
     mockedSession.mockReturnValue({ data: { user: { id: "u1" } } });
     mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    mockedIsFollowing.mockResolvedValue(false);
     mockedFollow.mockResolvedValue();
     const user = userEvent.setup();
 
     render(<FollowUserButton profileId="p2" />);
 
-    const btn = screen.getByRole("button", { name: /follow/i });
+    const btn = await screen.findByRole("button", { name: /follow/i });
     await user.click(btn);
 
     expect(mockedFollow).toHaveBeenCalledWith("p1", "p2");
-    expect(btn).toBeDisabled();
-    expect(await screen.findByText(/following/i)).toBeInTheDocument();
+    expect(btn).toHaveTextContent(/unfollow/i);
+  });
+
+  it("unfollows a user", async () => {
+    mockedSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    mockedIsFollowing.mockResolvedValue(true);
+    mockedUnfollow.mockResolvedValue();
+    const user = userEvent.setup();
+
+    render(<FollowUserButton profileId="p2" />);
+
+    const btn = await screen.findByRole("button", { name: /unfollow/i });
+    await user.click(btn);
+
+    expect(mockedUnfollow).toHaveBeenCalledWith("p1", "p2");
+    expect(btn).toHaveTextContent(/follow/i);
   });
 });

--- a/src/components/__tests__/ProfileSearch.test.tsx
+++ b/src/components/__tests__/ProfileSearch.test.tsx
@@ -29,7 +29,10 @@ describe("ProfileSearch", () => {
       if (url.includes("/byUser/")) {
         return Promise.resolve({ data: { id: "p1" } });
       }
-      return Promise.resolve({ data: [{ id: "p2", username: "runner" }] });
+      if (url.includes("/search")) {
+        return Promise.resolve({ data: [{ id: "p2", username: "runner" }] });
+      }
+      return Promise.resolve({ data: { following: false } });
     });
     const user = userEvent.setup();
 

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { createSocialProfile, followUser, unfollowUser, createPost } from "../social";
+import { createSocialProfile, followUser, unfollowUser, createPost, isFollowing } from "../social";
 import type { RunPost } from "@maratypes/social";
 
 jest.mock("axios");
@@ -26,6 +26,15 @@ describe("social api helpers", () => {
     mockedAxios.delete.mockResolvedValue({ data: {} });
     await unfollowUser("a", "b");
     expect(mockedAxios.delete).toHaveBeenCalledWith("/api/social/follow", { data: { followerId: "a", followingId: "b" } });
+  });
+
+  it("isFollowing fetches data", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { following: true } });
+    const result = await isFollowing("a", "b");
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "/api/social/follow?followerId=a&followingId=b"
+    );
+    expect(result).toBe(true);
   });
 
   it("createPost posts data", async () => {

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -27,6 +27,16 @@ export const unfollowUser = async (
   });
 };
 
+export const isFollowing = async (
+  followerId: string,
+  followingId: string
+): Promise<boolean> => {
+  const { data } = await axios.get<{ following: boolean }>(
+    `/api/social/follow?followerId=${followerId}&followingId=${followingId}`
+  );
+  return data.following;
+};
+
 export const createPost = async (
   data: Partial<RunPost>
 ): Promise<RunPost> => {


### PR DESCRIPTION
## Summary
- add GET handler to follow API to check follow status
- expose `isFollowing` API helper
- enhance `FollowUserButton` to toggle follow/unfollow
- reuse `FollowUserButton` in search results
- update tests for new behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aea87c2688324aa903b1a7a45b48c