### PR TITLE
Add user social profile pages

### DIFF
--- a/src/app/api/social/profile/[id]/route.ts
+++ b/src/app/api/social/profile/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function PUT(req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
+  const data = await req.json();
+  try {
+    const profile = await prisma.userProfile.update({
+      where: { id },
+      data: {
+        username: data.username,
+        bio: data.bio,
+        profilePhoto: data.profilePhoto,
+      },
+    });
+    return NextResponse.json(profile);
+  } catch (err) {
+    console.error("Error updating profile", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/profile/[username]/posts/route.ts
+++ b/src/app/api/social/profile/[username]/posts/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(_req: NextRequest, ctx: { params: { username: string } }) {
+  const { username } = ctx.params;
+  try {
+    const profile = await prisma.userProfile.findUnique({ where: { username } });
+    if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const posts = await prisma.runPost.findMany({
+      where: { userProfileId: profile.id },
+      include: { _count: { select: { likes: true, comments: true } } },
+      orderBy: { createdAt: "desc" },
+    });
+    return NextResponse.json(posts);
+  } catch (err) {
+    console.error("Error fetching posts", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/social/profile/edit/page.tsx
+++ b/src/app/social/profile/edit/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+import SocialProfileEditForm from "@components/SocialProfileEditForm";
+
+export default function EditSocialProfilePage() {
+  const { profile, loading } = useSocialProfile();
+
+  if (loading) return <p className="w-full px-4 py-6">Loading...</p>;
+  if (!profile) return <p className="w-full px-4 py-6">Profile not found.</p>;
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6 flex justify-center">
+      <SocialProfileEditForm profile={profile} />
+    </div>
+  );
+}

--- a/src/components/SocialProfileEditForm.tsx
+++ b/src/components/SocialProfileEditForm.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import type { SocialUserProfile } from "@maratypes/social";
+import { updateSocialProfile } from "@lib/api/social";
+import { Card, Button } from "@components/ui";
+import { TextField, TextAreaField } from "@components/ui/FormField";
+
+interface Props {
+  profile: SocialUserProfile;
+  onUpdated?: (p: SocialUserProfile) => void;
+}
+
+export default function SocialProfileEditForm({ profile, onUpdated }: Props) {
+  const [username, setUsername] = useState(profile.username);
+  const [bio, setBio] = useState(profile.bio ?? "");
+  const [profilePhoto, setProfilePhoto] = useState(profile.profilePhoto ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      const updated = await updateSocialProfile(profile.id, {
+        username,
+        bio,
+        profilePhoto,
+      });
+      setSuccess(true);
+      onUpdated?.(updated);
+      setTimeout(() => setSuccess(false), 2000);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to update profile");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="p-6 w-full max-w-md">
+      <h2 className="text-2xl font-semibold mb-4">Edit Social Profile</h2>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      {success && <p className="text-primary mb-2">Profile updated!</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          label="Username"
+          name="username"
+          value={username}
+          onChange={(_n, v) => setUsername(String(v))}
+          required
+        />
+        <TextAreaField
+          label="Bio"
+          name="bio"
+          value={bio}
+          onChange={(_n, v) => setBio(String(v))}
+          rows={2}
+        />
+        <TextField
+          label="Profile Photo URL"
+          name="profilePhoto"
+          value={profilePhoto}
+          onChange={(_n, v) => setProfilePhoto(String(v))}
+        />
+        <div className="flex justify-end">
+          <Button type="submit" disabled={saving}>
+            Save Changes
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -1,5 +1,12 @@
 import axios from "axios";
-import { createSocialProfile, followUser, unfollowUser, createPost, isFollowing } from "../social";
+import {
+  createSocialProfile,
+  followUser,
+  unfollowUser,
+  createPost,
+  isFollowing,
+  updateSocialProfile,
+} from "../social";
 import type { RunPost } from "@maratypes/social";
 
 jest.mock("axios");
@@ -43,5 +50,12 @@ describe("social api helpers", () => {
     const result = await createPost({ distance: 1 });
     expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/posts", { distance: 1 });
     expect(result).toEqual(post);
+  });
+
+  it("updateSocialProfile puts data", async () => {
+    mockedAxios.put.mockResolvedValue({ data: { id: "p1", username: "t" } });
+    const result = await updateSocialProfile("p1", { bio: "hi" });
+    expect(mockedAxios.put).toHaveBeenCalledWith("/api/social/profile/p1", { bio: "hi" });
+    expect(result).toEqual({ id: "p1", username: "t" });
   });
 });

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -44,3 +44,14 @@ export const createPost = async (
   return post;
 };
 
+
+export const updateSocialProfile = async (
+  id: string,
+  data: Partial<SocialUserProfile>
+): Promise<SocialUserProfile> => {
+  const { data: profile } = await axios.put<SocialUserProfile>(
+    `/api/social/profile/${id}`,
+    data
+  );
+  return profile;
+};


### PR DESCRIPTION
## Summary
- add API to update social profile
- add API to list posts for a user profile
- support updating profiles via `updateSocialProfile`
- create edit form and page for social profiles
- show posts, follower info and edit option on `/u/[username]`
- test the new API helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684afe753a44832493f9e82c020e3206