### PR TITLE
Ensure usernames link to social pages

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -123,13 +123,21 @@ export default async function UserProfilePage({ params }: Props) {
           <h2 className="text-xl font-semibold">Followers</h2>
           <ul className="list-disc ml-6">
             {data.followers.map((f: SocialUserProfile) => (
-              <li key={f.id}>{f.username}</li>
+              <li key={f.id}>
+                <Link href={`/u/${f.username}`} className="hover:underline">
+                  {f.username}
+                </Link>
+              </li>
             ))}
           </ul>
           <h2 className="text-xl font-semibold">Following</h2>
           <ul className="list-disc ml-6">
             {data.following.map((f: SocialUserProfile) => (
-              <li key={f.id}>{f.username}</li>
+              <li key={f.id}>
+                <Link href={`/u/${f.username}`} className="hover:underline">
+                  {f.username}
+                </Link>
+              </li>
             ))}
           </ul>
           <p className="text-sm text-foreground/60">

--- a/src/components/SocialFeed.tsx
+++ b/src/components/SocialFeed.tsx
@@ -6,6 +6,7 @@ import { useSession } from "next-auth/react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import CreateSocialPost from "@components/CreateSocialPost";
 import { Button } from "@components/ui";
+import Link from "next/link";
 
 export default function SocialFeed() {
   const { data: session } = useSession();
@@ -59,9 +60,14 @@ export default function SocialFeed() {
                 className="w-8 h-8 rounded-full object-cover"
               />
             )}
-            <span className="font-semibold">
-              {post.userProfile?.username}
-            </span>
+            {post.userProfile?.username && (
+              <Link
+                href={`/u/${post.userProfile.username}`}
+                className="font-semibold hover:underline"
+              >
+                {post.userProfile.username}
+              </Link>
+            )}
           </div>
           <p className="font-medium">
             {post.distance} mi in {post.time}


### PR DESCRIPTION
## Summary
- link usernames in social feed to their social profiles
- link follower and following lists to profile pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b02354fe48324ad34ae0650d0ecbf