### PR TITLE
Style social pages like home

### DIFF
--- a/src/app/api/social/feed/route.ts
+++ b/src/app/api/social/feed/route.ts
@@ -14,7 +14,11 @@ export async function GET(req: NextRequest) {
     const ids = followed.map((f) => f.followingId);
     const posts = await prisma.runPost.findMany({
       where: { userProfileId: { in: ids } },
-      include: { userProfile: true },
+      include: {
+        userProfile: {
+          include: { user: { select: { avatarUrl: true } } },
+        },
+      },
       orderBy: { createdAt: "desc" },
     });
     return NextResponse.json(posts);

--- a/src/app/api/social/search/route.ts
+++ b/src/app/api/social/search/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
         })),
       },
       include: {
-        user: { select: { name: true, _count: { select: { runs: true } } } },
+        user: { select: { name: true, avatarUrl: true, _count: { select: { runs: true } } } },
         _count: { select: { followers: true, following: true } },
       },
       take: 10,
@@ -34,6 +34,7 @@ export async function GET(req: NextRequest) {
           username: p.username,
           bio: p.bio,
           profilePhoto: p.profilePhoto,
+          avatarUrl: p.user.avatarUrl,
           createdAt: p.createdAt,
           updatedAt: p.updatedAt,
           name: p.user.name,

--- a/src/app/social/profile/edit/page.tsx
+++ b/src/app/social/profile/edit/page.tsx
@@ -9,8 +9,10 @@ export default function EditSocialProfilePage() {
   if (!profile) return <p className="w-full px-4 py-6">Profile not found.</p>;
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6 flex justify-center">
-      <SocialProfileEditForm profile={profile} />
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+      <div className="flex justify-center">
+        <SocialProfileEditForm profile={profile} />
+      </div>
     </div>
   );
 }

--- a/src/app/social/profile/new/page.tsx
+++ b/src/app/social/profile/new/page.tsx
@@ -2,8 +2,10 @@ import SocialProfileForm from "@components/SocialProfileForm";
 
 export default function NewSocialProfilePage() {
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6 flex justify-center">
-      <SocialProfileForm />
+    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+      <div className="flex justify-center">
+        <SocialProfileForm />
+      </div>
     </div>
   );
 }

--- a/src/app/social/search/page.tsx
+++ b/src/app/social/search/page.tsx
@@ -3,8 +3,10 @@ import ProfileSearch from "@components/ProfileSearch";
 export default function SearchPage() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-      <h1 className="text-2xl font-bold mb-4">Find Runners</h1>
-      <ProfileSearch />
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Find Runners</h1>
+        <ProfileSearch />
+      </div>
     </div>
   );
 }

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../api/auth/[...nextauth]/route";
 import type { SocialUserProfile, RunPost } from "@maratypes/social";
@@ -10,7 +11,7 @@ async function getProfileData(username: string) {
   const profile = await prisma.userProfile.findUnique({
     where: { username },
     include: {
-      user: { select: { name: true, _count: { select: { runs: true } } } },
+      user: { select: { name: true, avatarUrl: true, _count: { select: { runs: true } } } },
       _count: { select: { followers: true, following: true } },
       followers: { select: { follower: true } },
       following: { select: { following: true } },
@@ -36,6 +37,7 @@ async function getProfileData(username: string) {
     username: profile.username,
     bio: profile.bio,
     profilePhoto: profile.profilePhoto,
+    avatarUrl: profile.user.avatarUrl,
     createdAt: profile.createdAt,
     updatedAt: profile.updatedAt,
     name: profile.user.name,
@@ -65,18 +67,17 @@ export default async function UserProfilePage({ params }: Props) {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-grow">
-        <section className="max-w-3xl mx-auto">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8">
+        <section className="max-w-3xl mx-auto py-6">
           <div className="p-4 space-y-6">
             <div className="flex items-center gap-6 p-4 rounded-md bg-background border">
-              {data.profilePhoto && (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={data.profilePhoto}
-                  alt={data.username}
-                  className="w-16 h-16 rounded-full object-cover"
-                />
-              )}
+              <Image
+                src={data.avatarUrl || data.profilePhoto || "/default_profile.png"}
+                alt={data.username}
+                width={64}
+                height={64}
+                className="w-16 h-16 rounded-full object-cover"
+              />
               <div>
                 <h1 className="text-2xl font-bold">{data.name ?? data.username}</h1>
                 {data.bio && <p className="text-foreground/70">{data.bio}</p>}

--- a/src/components/DefaultAvatar.tsx
+++ b/src/components/DefaultAvatar.tsx
@@ -1,26 +1,20 @@
-import { Bike, Dumbbell, Apple, Heart, Mountain, Footprints } from "lucide-react";
+import Image from "next/image";
 import React from "react";
 
-const icons = [Bike, Dumbbell, Apple, Heart, Mountain, Footprints];
-
 export interface DefaultAvatarProps {
-  /** Seed value to deterministically pick an icon */
-  seed?: string;
   /** Size of the avatar circle */
   size?: number;
   className?: string;
 }
 
-export default function DefaultAvatar({ seed = "", size = 32, className = "" }: DefaultAvatarProps) {
-  const index = Array.from(seed).reduce((sum, ch) => sum + ch.charCodeAt(0), 0) % icons.length;
-  const IconComp = icons[index];
-  const iconSize = Math.floor(size * 0.6);
+export default function DefaultAvatar({ size = 32, className = "" }: DefaultAvatarProps) {
   return (
-    <div
-      className={`flex items-center justify-center rounded-full bg-muted text-muted-foreground ${className}`}
-      style={{ width: size, height: size }}
-    >
-      <IconComp size={iconSize} />
-    </div>
+    <Image
+      src="/default_profile.png"
+      alt="Default avatar"
+      width={size}
+      height={size}
+      className={`rounded-full object-cover ${className}`}
+    />
   );
 }

--- a/src/components/ProfileSearch.tsx
+++ b/src/components/ProfileSearch.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import type { SocialUserProfile } from "@maratypes/social";
 import { Input, Button, Card } from "@components/ui";
 import FollowUserButton from "@components/FollowUserButton";
+import Image from "next/image";
 
 export default function ProfileSearch() {
   const { data: session } = useSession();
@@ -89,14 +90,23 @@ export default function ProfileSearch() {
       <div className="space-y-4">
         {results.map((p) => (
           <Card key={p.id} className="p-4 flex items-center justify-between">
-            <div>
-              <a href={`/u/${p.username}`} className="font-semibold">
-                {p.name ?? p.username}
-              </a>
-              {p.bio && <p className="text-foreground/70">{p.bio}</p>}
-              <div className="text-sm text-foreground/60">
-                <span>{p.runCount ?? 0} runs</span>{" "}
-                <span>{p.followerCount ?? 0} followers</span>
+            <div className="flex items-center gap-4">
+              <Image
+                src={p.avatarUrl || "/default_profile.png"}
+                alt={p.username}
+                width={40}
+                height={40}
+                className="w-10 h-10 rounded-full object-cover"
+              />
+              <div>
+                <a href={`/u/${p.username}`} className="font-semibold">
+                  {p.name ?? p.username}
+                </a>
+                {p.bio && <p className="text-foreground/70">{p.bio}</p>}
+                <div className="text-sm text-foreground/60">
+                  <span>{p.runCount ?? 0} runs</span>{" "}
+                  <span>{p.followerCount ?? 0} followers</span>
+                </div>
               </div>
             </div>
             {myProfileId && myProfileId !== p.id && (

--- a/src/components/SocialFeed.tsx
+++ b/src/components/SocialFeed.tsx
@@ -7,6 +7,7 @@ import { useSocialProfile } from "@hooks/useSocialProfile";
 import CreateSocialPost from "@components/CreateSocialPost";
 import { Button } from "@components/ui";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function SocialFeed() {
   const { data: session } = useSession();
@@ -52,14 +53,17 @@ export default function SocialFeed() {
       {posts.map((post) => (
         <div key={post.id} className="border rounded-md p-4">
           <div className="flex items-center gap-2 mb-2">
-            {post.userProfile?.profilePhoto && (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={post.userProfile.profilePhoto}
-                alt={post.userProfile.username}
-                className="w-8 h-8 rounded-full object-cover"
-              />
-            )}
+            <Image
+              src={
+                post.userProfile?.user?.avatarUrl ||
+                post.userProfile?.profilePhoto ||
+                "/default_profile.png"
+              }
+              alt={post.userProfile?.username || "avatar"}
+              width={32}
+              height={32}
+              className="w-8 h-8 rounded-full object-cover"
+            />
             {post.userProfile?.username && (
               <Link
                 href={`/u/${post.userProfile.username}`}

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -4,6 +4,7 @@ export interface SocialUserProfile {
   username: string;
   bio?: string;
   profilePhoto?: string;
+  avatarUrl?: string;
   createdAt: Date;
   updatedAt: Date;
   name?: string;
@@ -22,7 +23,7 @@ export interface RunPost {
   photoUrl?: string;
   createdAt: Date;
   updatedAt: Date;
-  userProfile?: SocialUserProfile;
+  userProfile?: SocialUserProfile & { user?: { avatarUrl?: string } };
   likeCount?: number;
   commentCount?: number;
 }


### PR DESCRIPTION
## Summary
- unify social page layout with home/landing formatting
- include avatar URL in feed API
- display avatars with `next/image` across social features

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b56f685448324b95a312c7789edaa