### PR TITLE
Add run selection when sharing posts

### DIFF
--- a/src/components/CreateSocialPost.tsx
+++ b/src/components/CreateSocialPost.tsx
@@ -1,9 +1,12 @@
 "use client";
-import { useState, FormEvent } from "react";
+import { useState, FormEvent, useEffect } from "react";
 import { createPost } from "@lib/api/social";
+import { listRuns } from "@lib/api/run";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import { Card, Button } from "@components/ui";
-import { TextField, TextAreaField } from "@components/ui/FormField";
+import { TextField, TextAreaField, SelectField } from "@components/ui/FormField";
+import { getRunName } from "@utils/running/getRunName";
+import type { Run } from "@maratypes/run";
 
 interface Props {
   onCreated?: () => void;
@@ -11,34 +14,52 @@ interface Props {
 
 export default function CreateSocialPost({ onCreated }: Props) {
   const { profile } = useSocialProfile();
-  const [distance, setDistance] = useState("");
-  const [time, setTime] = useState("");
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [selectedRunId, setSelectedRunId] = useState("");
   const [caption, setCaption] = useState("");
   const [photoUrl, setPhotoUrl] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+  const [loadingRuns, setLoadingRuns] = useState(true);
 
-  if (!profile) return null;
+  useEffect(() => {
+    const fetchRuns = async () => {
+      if (!profile?.userId) return;
+      try {
+        const allRuns = await listRuns();
+        const userRuns = allRuns
+          .filter((r) => r.userId === profile.userId)
+          .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+          .slice(0, 5);
+        setRuns(userRuns);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoadingRuns(false);
+      }
+    };
+    fetchRuns();
+  }, [profile?.userId]);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
     setSuccess("");
-    if (!distance || !time) {
-      setError("Distance and time required");
+    const run = runs.find((r) => r.id === selectedRunId);
+    if (!run) {
+      setError("Please select a run");
       return;
     }
     try {
       await createPost({
         userProfileId: profile.id,
-        distance: parseFloat(distance),
-        time,
+        distance: run.distance,
+        time: run.duration,
         caption: caption || undefined,
         photoUrl: photoUrl || undefined,
       });
       setSuccess("Posted!");
-      setDistance("");
-      setTime("");
+      setSelectedRunId("");
       setCaption("");
       setPhotoUrl("");
       onCreated?.();
@@ -47,27 +68,31 @@ export default function CreateSocialPost({ onCreated }: Props) {
     }
   };
 
+  if (!profile) return null;
+
   return (
     <Card className="p-4 mb-6">
       <h3 className="text-lg font-semibold mb-2">Share a Run</h3>
       {error && <p className="text-red-600 mb-2">{error}</p>}
       {success && <p className="text-primary mb-2">{success}</p>}
       <form onSubmit={handleSubmit} className="space-y-2">
-        <TextField
-          label="Distance (mi)"
-          name="distance"
-          type="number"
-          value={distance}
-          onChange={(_n, v) => setDistance(String(v))}
-          required
-        />
-        <TextField
-          label="Time (HH:MM:SS)"
-          name="time"
-          value={time}
-          onChange={(_n, v) => setTime(String(v))}
-          required
-        />
+        {loadingRuns ? (
+          <p>Loading runs...</p>
+        ) : runs.length === 0 ? (
+          <p>No recent runs found.</p>
+        ) : (
+          <SelectField
+            label="Run"
+            name="run"
+            options={runs.map((r) => ({
+              value: r.id ?? "",
+              label: `${r.name || getRunName(r)} - ${r.distance} ${r.distanceUnit}`,
+            }))}
+            value={selectedRunId}
+            onChange={(_n, v) => setSelectedRunId(String(v))}
+            required
+          />
+        )}
         <TextAreaField
           label="Caption"
           name="caption"

--- a/src/components/__tests__/CreateSocialPost.test.tsx
+++ b/src/components/__tests__/CreateSocialPost.test.tsx
@@ -1,16 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import "@testing-library/jest-dom";
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CreateSocialPost from "../CreateSocialPost";
 import { createPost } from "@lib/api/social";
+import { listRuns } from "@lib/api/run";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 
 jest.mock("@lib/api/social");
+jest.mock("@lib/api/run", () => ({ listRuns: jest.fn() }));
 jest.mock("@hooks/useSocialProfile", () => ({ useSocialProfile: jest.fn() }));
 
 const mockedCreate = createPost as jest.MockedFunction<typeof createPost>;
+const mockedListRuns = listRuns as jest.MockedFunction<typeof listRuns>;
 const mockedUseProfile = useSocialProfile as jest.Mock;
 
 describe("CreateSocialPost", () => {
@@ -19,15 +22,25 @@ describe("CreateSocialPost", () => {
   });
 
   it("submits post data", async () => {
-    mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1", userId: "u1" } });
     mockedCreate.mockResolvedValue({ id: "post1" } as any);
+    mockedListRuns.mockResolvedValue([
+      {
+        id: "r1",
+        userId: "u1",
+        date: new Date().toISOString(),
+        distance: 3,
+        distanceUnit: "miles",
+        duration: "00:20:00",
+      } as any,
+    ]);
     const onCreated = jest.fn();
     const user = userEvent.setup();
 
     render(<CreateSocialPost onCreated={onCreated} />);
 
-    await user.type(screen.getByLabelText(/distance/i), "3");
-    await user.type(screen.getByLabelText(/time/i), "00:20:00");
+    await waitFor(() => expect(mockedListRuns).toHaveBeenCalled());
+    await user.selectOptions(await screen.findByLabelText(/run/i), "r1");
     await user.type(screen.getByLabelText(/caption/i), "Nice run");
     await user.click(screen.getByRole("button", { name: /post/i }));
 
@@ -43,13 +56,25 @@ describe("CreateSocialPost", () => {
   });
 
   it("shows error when required fields missing", async () => {
-    mockedUseProfile.mockReturnValue({ profile: { id: "p1" } });
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1", userId: "u1" } });
+    mockedListRuns.mockResolvedValue([
+      {
+        id: "r1",
+        userId: "u1",
+        date: new Date().toISOString(),
+        distance: 3,
+        distanceUnit: "miles",
+        duration: "00:20:00",
+      } as any,
+    ]);
     render(<CreateSocialPost />);
 
-    const form = screen.getByRole("button", { name: /post/i }).closest("form")!;
+    const form = await screen
+      .findByRole("button", { name: /post/i })
+      .then((btn) => btn.closest("form")!);
     fireEvent.submit(form);
 
     expect(mockedCreate).not.toHaveBeenCalled();
-    expect(await screen.findByText(/distance and time required/i)).toBeInTheDocument();
+    expect(await screen.findByText(/select a run/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- allow selecting one of your recent runs when creating a social post
- update CreateSocialPost tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b646fd7288324906028f295dc277f