### PR TITLE
Align User interface with Prisma schema

### DIFF
--- a/src/app/(auth)/signup/profile/page.tsx
+++ b/src/app/(auth)/signup/profile/page.tsx
@@ -4,7 +4,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { updateUserProfile } from "@lib/api/user/user";
 import UserProfileForm from "@components/UserProfileForm";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import { useEffect } from "react";
 import { Card } from "@components/ui";
 
@@ -27,15 +27,15 @@ export default function OnboardingProfile() {
 
   // Prefill the form using session.user
   // You'll need to load any additional fields from your database if needed
-  const initialUser: UserProfile = {
+  const initialUser: User = {
     id: session.user.id!,
     name: session.user.name ?? "",
     email: session.user.email ?? "",
 
-    // ...other fields (may need to fetch from API if your UserProfile is more than name/email)
+  // ...other fields (may need to fetch from API if your User is more than name/email)
   };
 
-  const onSave = async (updated: UserProfile) => {
+  const onSave = async (updated: User) => {
     await updateUserProfile(initialUser.id, updated);
     // Refresh session so avatar updates in navbar
     await update({ user: { avatarUrl: updated.avatarUrl ?? null } });

--- a/src/app/(auth)/userProfile/page.tsx
+++ b/src/app/(auth)/userProfile/page.tsx
@@ -4,12 +4,12 @@
 import React, { useEffect, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import UserProfileForm from "@components/UserProfileForm";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import { getUserProfile, updateUserProfile } from "@lib/api/user/user";
 
 export default function UserProfilePage() {
   const { data: session, status, update } = useSession();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profile, setProfile] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -36,7 +36,7 @@ export default function UserProfilePage() {
   }, [session, status]);
 
   // Handle save
-  const handleSave = async (updated: UserProfile) => {
+  const handleSave = async (updated: User) => {
     try {
       setLoading(true);
       await updateUserProfile(updated.id, updated);

--- a/src/app/social/feed/page.tsx
+++ b/src/app/social/feed/page.tsx
@@ -2,9 +2,11 @@ import SocialFeed from "@components/SocialFeed";
 
 export default function FeedPage() {
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-      <h1 className="text-2xl font-bold mb-4">Your Feed</h1>
-      <SocialFeed />
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6">
+        <h1 className="text-2xl font-bold mb-4">Your Feed</h1>
+        <SocialFeed />
+      </main>
     </div>
   );
 }

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { Card } from "@components/ui";
+import { Users, Activity, User } from "lucide-react";
+
+export default function SocialHomePage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 bg-background text-foreground space-y-10 pt-8 pb-20">
+      <h1 className="text-3xl font-bold">Social Hub</h1>
+      <div className="h-1 w-24 mb-6 bg-gradient-to-r from-brand-from to-brand-to rounded" />
+      <section>
+        <h2 className="text-2xl font-bold mb-4">Quick Links</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <Link href="/social/feed">
+            <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+              <Activity className="w-5 h-5" />
+              <span>Your Feed</span>
+            </Card>
+          </Link>
+          <Link href="/social/search">
+            <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+              <Users className="w-5 h-5" />
+              <span>Find Runners</span>
+            </Card>
+          </Link>
+          <Link href="/social/profile/edit">
+            <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
+              <User className="w-5 h-5" />
+              <span>Your Profile</span>
+            </Card>
+          </Link>
+        </div>
+      </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/social/profile/edit/page.tsx
+++ b/src/app/social/profile/edit/page.tsx
@@ -9,10 +9,12 @@ export default function EditSocialProfilePage() {
   if (!profile) return <p className="w-full px-4 py-6">Profile not found.</p>;
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-      <div className="flex justify-center">
-        <SocialProfileEditForm profile={profile} />
-      </div>
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex justify-center">
+          <SocialProfileEditForm profile={profile} />
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/app/social/profile/new/page.tsx
+++ b/src/app/social/profile/new/page.tsx
@@ -2,10 +2,12 @@ import SocialProfileForm from "@components/SocialProfileForm";
 
 export default function NewSocialProfilePage() {
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-      <div className="flex justify-center">
-        <SocialProfileForm />
-      </div>
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex justify-center">
+          <SocialProfileForm />
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/app/social/search/page.tsx
+++ b/src/app/social/search/page.tsx
@@ -2,11 +2,13 @@ import ProfileSearch from "@components/ProfileSearch";
 
 export default function SearchPage() {
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-      <div className="max-w-3xl mx-auto">
-        <h1 className="text-2xl font-bold mb-4">Find Runners</h1>
-        <ProfileSearch />
-      </div>
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Find Runners</h1>
+          <ProfileSearch />
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -11,7 +11,14 @@ async function getProfileData(username: string) {
   const profile = await prisma.userProfile.findUnique({
     where: { username },
     include: {
-      user: { select: { name: true, avatarUrl: true, _count: { select: { runs: true } } } },
+      user: {
+        select: {
+          name: true,
+          avatarUrl: true,
+          createdAt: true,
+          _count: { select: { runs: true } },
+        },
+      },
       _count: { select: { followers: true, following: true } },
       followers: { select: { follower: true } },
       following: { select: { following: true } },
@@ -38,6 +45,7 @@ async function getProfileData(username: string) {
     bio: profile.bio,
     profilePhoto: profile.profilePhoto,
     avatarUrl: profile.user.avatarUrl,
+    userCreatedAt: profile.user.createdAt,
     createdAt: profile.createdAt,
     updatedAt: profile.updatedAt,
     name: profile.user.name,
@@ -80,6 +88,10 @@ export default async function UserProfilePage({ params }: Props) {
               />
               <div>
                 <h1 className="text-2xl font-bold">{data.name ?? data.username}</h1>
+                <p className="text-sm text-foreground/60">
+                  @{data.username} • Joined{' '}
+                  {new Date(data.userCreatedAt).toLocaleDateString()}
+                </p>
                 {data.bio && <p className="text-foreground/70">{data.bio}</p>}
               </div>
             </div>
@@ -112,6 +124,9 @@ export default async function UserProfilePage({ params }: Props) {
                 <p className="text-base font-semibold">
                   {post.distance} mi in {post.time}
                 </p>
+                <div className="text-sm text-foreground/60">
+                  {new Date(post.createdAt).toLocaleString()}
+                </div>
                 {post.caption && <p className="mt-2">{post.caption}</p>}
                 {post.photoUrl && (
                   // eslint-disable-next-line @next/next/no-img-element

--- a/src/components/SocialFeed.tsx
+++ b/src/components/SocialFeed.tsx
@@ -52,7 +52,7 @@ export default function SocialFeed() {
       {posts.length === 0 && <p>No posts yet.</p>}
       {posts.map((post) => (
         <div key={post.id} className="border rounded-md p-4">
-          <div className="flex items-center gap-2 mb-2">
+          <div className="flex items-center gap-2 mb-1">
             <Image
               src={
                 post.userProfile?.user?.avatarUrl ||
@@ -72,6 +72,9 @@ export default function SocialFeed() {
                 {post.userProfile.username}
               </Link>
             )}
+          </div>
+          <div className="text-sm text-foreground/60 mb-2">
+            {new Date(post.createdAt).toLocaleString()}
           </div>
           <p className="font-medium">
             {post.distance} mi in {post.time}

--- a/src/components/UserProfileForm/BasicInfoSection.tsx
+++ b/src/components/UserProfileForm/BasicInfoSection.tsx
@@ -1,5 +1,5 @@
 import { TextField, SelectField, AvatarUpload } from "@components/ui";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import styles from "./Section.module.css";
 import type { Gender } from "@maratypes/user";
 import Image from "next/image";
@@ -15,9 +15,9 @@ const genderOptions = genderValues.map((g) => ({
 }));
 
 interface Props {
-  formData: Partial<UserProfile>;
+  formData: Partial<User>;
   isEditing: boolean;
-  onChange: (field: keyof UserProfile, value: string) => void;
+  onChange: (field: keyof User, value: string) => void;
 }
 
 export default function BasicInfoSection({
@@ -26,7 +26,7 @@ export default function BasicInfoSection({
   onChange,
 }: Props) {
   const handleFieldChange = (name: string, value: string) =>
-    onChange(name as keyof UserProfile, value);
+    onChange(name as keyof User, value);
 
 
   return (

--- a/src/components/UserProfileForm/GoalsSection.tsx
+++ b/src/components/UserProfileForm/GoalsSection.tsx
@@ -1,15 +1,15 @@
 import styles from "./Section.module.css";
 import { TextAreaField } from "@components/ui";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 
-// Generic change handler for exactly matching UserProfile field types
-export type ChangeHandler = <K extends keyof UserProfile>(
+// Generic change handler for exactly matching User field types
+export type ChangeHandler = <K extends keyof User>(
   field: K,
-  value: UserProfile[K]
+  value: User[K]
 ) => void;
 
 interface Props {
-  formData: Partial<UserProfile>;
+  formData: Partial<User>;
   isEditing: boolean;
   onChange: ChangeHandler;
 }
@@ -34,7 +34,7 @@ export default function GoalsSection({ formData, isEditing, onChange }: Props) {
             name="injuryHistory"
             value={formData.injuryHistory || ""}
             editing={isEditing}
-            onChange={(name, value) => onChange(name as keyof UserProfile, value)}
+            onChange={(name, value) => onChange(name as keyof User, value)}
           />
         </div>
       ) : (

--- a/src/components/UserProfileForm/PhysicalStatsSection.tsx
+++ b/src/components/UserProfileForm/PhysicalStatsSection.tsx
@@ -1,10 +1,10 @@
 import { TextField } from "@components/ui";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import { ChangeHandler } from "./GoalsSection";
 import styles from "./Section.module.css";
 
 interface Props {
-  formData: Partial<UserProfile>;
+  formData: Partial<User>;
   isEditing: boolean;
   onChange: ChangeHandler;
 }
@@ -25,7 +25,7 @@ export default function PhysicalStatsSection({
             type="number"
             value={formData.height ?? ""}
             editing={isEditing}
-            onChange={(name, value) => onChange(name as keyof UserProfile, value)}
+            onChange={(name, value) => onChange(name as keyof User, value)}
           />
           <TextField
             label="Weight (lbs)"
@@ -33,7 +33,7 @@ export default function PhysicalStatsSection({
             type="number"
             value={formData.weight ?? ""}
             editing={isEditing}
-            onChange={(name, value) => onChange(name as keyof UserProfile, value)}
+            onChange={(name, value) => onChange(name as keyof User, value)}
           />
           <TextField
             label="Years Running"
@@ -41,7 +41,7 @@ export default function PhysicalStatsSection({
             type="number"
             value={formData.yearsRunning ?? ""}
             editing={isEditing}
-            onChange={(name, value) => onChange(name as keyof UserProfile, value)}
+            onChange={(name, value) => onChange(name as keyof User, value)}
           />
           {/* Weekly mileage shouldn't be editable by user */}
           {/* <TextField

--- a/src/components/UserProfileForm/PreferencesSection.tsx
+++ b/src/components/UserProfileForm/PreferencesSection.tsx
@@ -1,5 +1,5 @@
 import { SelectField, CheckboxGroupField } from "@components/ui";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import { ChangeHandler } from "./GoalsSection";
 import styles from "./Section.module.css";
 // import type { DayOfWeek } from "@maratypes/user";
@@ -17,7 +17,7 @@ const deviceOptions = [
 ];
 
 interface Props {
-  formData: Partial<UserProfile>;
+  formData: Partial<User>;
   isEditing: boolean;
   onChange: ChangeHandler;
 }
@@ -47,7 +47,7 @@ export default function PreferencesSection({
             value={formData.preferredTrainingDays || []}
             editing={isEditing}
             onChange={(name, value) =>
-              onChange(name as keyof UserProfile, value)
+              onChange(name as keyof User, value)
             }
           />
           <SelectField
@@ -62,7 +62,7 @@ export default function PreferencesSection({
             value={formData.preferredTrainingEnvironment || ""}
             editing={isEditing}
             onChange={(name, value) =>
-              onChange(name as keyof UserProfile, value)
+              onChange(name as keyof User, value)
             }
           />
           <SelectField
@@ -72,7 +72,7 @@ export default function PreferencesSection({
             value={formData.device || ""}
             editing={isEditing}
             onChange={(name, value) =>
-              onChange(name as keyof UserProfile, value)
+              onChange(name as keyof User, value)
             }
           />
         </div>

--- a/src/components/UserProfileForm/index.tsx
+++ b/src/components/UserProfileForm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import BasicInfoSection from "./BasicInfoSection";
 import PhysicalStatsSection from "./PhysicalStatsSection";
 import GoalsSection from "./GoalsSection";
@@ -9,8 +9,8 @@ import { useUserProfileForm } from "@hooks/useUserProfileForm";
 import { Button } from "@components/ui";
 
 interface Props {
-  initialUser: UserProfile;
-  onSave: (u: UserProfile) => void;
+  initialUser: User;
+  onSave: (u: User) => void;
   /** always show fields in edit mode */
   alwaysEdit?: boolean;
   submitLabel?: string;

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,12 +1,12 @@
 // src/hooks/useUserProfile.ts
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import axios from "axios";
 
 export function useUserProfile() {
   const { data: session } = useSession();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profile, setProfile] = useState<User | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {

--- a/src/hooks/useUserProfileForm.ts
+++ b/src/hooks/useUserProfileForm.ts
@@ -2,15 +2,15 @@ import { useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import userProfileSchema from "@lib/schemas/userProfileSchema";
 import isYupValidationError from "@lib/utils/validation/isYupValidationError";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 import { updateUserProfile } from "@lib/api/user/user";
 
 export function useUserProfileForm(
-  initial: UserProfile,
-  onSuccess: (u: UserProfile) => void
+  initial: User,
+  onSuccess: (u: User) => void
 ) {
   const { update } = useSession();
-  const [formData, setFormData] = useState<Partial<UserProfile>>(initial);
+  const [formData, setFormData] = useState<Partial<User>>(initial);
   const [isEditing, setIsEditing] = useState(false);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
@@ -20,7 +20,7 @@ export function useUserProfileForm(
     setFormData(initial);
   }, [initial]);
 
-  const handleChange = useCallback((field: keyof UserProfile, value: UserProfile[keyof UserProfile]) => {
+  const handleChange = useCallback((field: keyof User, value: User[keyof User]) => {
     setFormData((fd) => ({ ...fd, [field]: value }));
   }, []);
 
@@ -32,7 +32,7 @@ export function useUserProfileForm(
         abortEarly: false,
         stripUnknown: true,
       });
-      const { id, ...payload } = valid as { id: string } & Partial<UserProfile>;
+      const { id, ...payload } = valid as { id: string } & Partial<User>;
       const updated = await updateUserProfile(id, payload);
       onSuccess(updated);
       if (update) {

--- a/src/lib/api/user/user.ts
+++ b/src/lib/api/user/user.ts
@@ -1,7 +1,7 @@
 //src/lib/api/user/user.ts
 
 import axios from "axios";
-import { UserProfile } from "@maratypes/user";
+import { User } from "@maratypes/user";
 
 export const uploadAvatar = async (file: File): Promise<string> => {
   const formData = new FormData();
@@ -16,7 +16,7 @@ export const uploadAvatar = async (file: File): Promise<string> => {
 // updates
 export const updateUserProfile = async (
   userId: string,
-  data: Partial<UserProfile>
+  data: Partial<User>
 ) => {
   // put req
   const response = await axios.put(`/api/users/${userId}`, data);
@@ -25,14 +25,14 @@ export const updateUserProfile = async (
 
 
 // creates new
-export const createUserProfile = async (data: Partial<UserProfile>) => {
+export const createUserProfile = async (data: Partial<User>) => {
   // post req
   const response = await axios.post(`/api/users`, data);
   return response;
 };
 
 // fetch by id
-export const getUserProfile = async (userId: string): Promise<UserProfile> => {
+export const getUserProfile = async (userId: string): Promise<User> => {
   const response = await axios.get(`/api/users/${userId}`);
   return response.data;
 };

--- a/src/lib/schemas/userProfileSchema.ts
+++ b/src/lib/schemas/userProfileSchema.ts
@@ -1,8 +1,7 @@
 import * as Yup from "yup";
-import { DayOfWeek } from "@maratypes/basics";
+import { DayOfWeek, TrainingEnvironment } from "@maratypes/basics";
 import {
   TrainingLevel,
-  TrainingEnvironment,
   Device,
 } from "@maratypes/user";
 

--- a/src/maratypes/user.ts
+++ b/src/maratypes/user.ts
@@ -20,7 +20,7 @@ export type Device =
 
 export type Gender = "Male" | "Female" | "Other";
 
-export interface UserProfile {
+export interface User {
   id: string;
   name: string;
   email: string;


### PR DESCRIPTION
## Summary
- rename `UserProfile` interface to `User`
- update imports and generics for renamed interface

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b7fe8b2608324b6d40a73e099d994