### PR TITLE
Use user avatar for social profile

### DIFF
--- a/src/app/api/social/profile/[username]/route.ts
+++ b/src/app/api/social/profile/[username]/route.ts
@@ -10,6 +10,7 @@ export async function GET(_req: NextRequest, ctx: { params: { username: string }
         user: {
           select: {
             name: true,
+            avatarUrl: true,
             _count: { select: { runs: true } },
           },
         },
@@ -28,7 +29,7 @@ export async function GET(_req: NextRequest, ctx: { params: { username: string }
       userId: profile.userId,
       username: profile.username,
       bio: profile.bio,
-      profilePhoto: profile.profilePhoto,
+      avatarUrl: profile.user.avatarUrl,
       createdAt: profile.createdAt,
       updatedAt: profile.updatedAt,
       name: profile.user.name,

--- a/src/app/api/social/profile/byUser/[id]/route.ts
+++ b/src/app/api/social/profile/byUser/[id]/route.ts
@@ -8,7 +8,7 @@ export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
       where: { userId: id },
       include: {
         user: {
-          select: { name: true, _count: { select: { runs: true } } },
+          select: { name: true, avatarUrl: true, _count: { select: { runs: true } } },
         },
         _count: { select: { followers: true, following: true } },
       },
@@ -25,7 +25,7 @@ export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
       userId: profile.userId,
       username: profile.username,
       bio: profile.bio,
-      profilePhoto: profile.profilePhoto,
+      avatarUrl: profile.user.avatarUrl,
       createdAt: profile.createdAt,
       updatedAt: profile.updatedAt,
       name: profile.user.name,

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -43,7 +43,6 @@ async function getProfileData(username: string) {
     userId: profile.userId,
     username: profile.username,
     bio: profile.bio,
-    profilePhoto: profile.profilePhoto,
     avatarUrl: profile.user.avatarUrl,
     userCreatedAt: profile.user.createdAt,
     createdAt: profile.createdAt,
@@ -80,7 +79,7 @@ export default async function UserProfilePage({ params }: Props) {
           <div className="p-4 space-y-6">
             <div className="flex items-center gap-6 p-4 rounded-md bg-background border">
               <Image
-                src={data.avatarUrl || data.profilePhoto || "/default_profile.png"}
+                src={data.avatarUrl || "/default_profile.png"}
                 alt={data.username}
                 width={64}
                 height={64}

--- a/src/components/__tests__/SocialProfileForm.test.tsx
+++ b/src/components/__tests__/SocialProfileForm.test.tsx
@@ -33,7 +33,6 @@ describe("SocialProfileForm", () => {
       userId: "u1",
       username: "tester",
       bio: undefined,
-      profilePhoto: undefined,
     });
     expect(onCreated).toHaveBeenCalled();
     expect(await screen.findByText(/profile created!/i)).toBeInTheDocument();

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -55,9 +55,7 @@ export default function SocialFeed() {
           <div className="flex items-center gap-2 mb-1">
             <Image
               src={
-                post.socialProfile?.user?.avatarUrl ||
-                post.socialProfile?.profilePhoto ||
-                "/default_profile.png"
+                post.socialProfile?.user?.avatarUrl || "/default_profile.png"
               }
               alt={post.socialProfile?.username || "avatar"}
               width={32}

--- a/src/components/social/SocialProfileEditForm.tsx
+++ b/src/components/social/SocialProfileEditForm.tsx
@@ -14,7 +14,6 @@ interface Props {
 export default function SocialProfileEditForm({ profile, onUpdated }: Props) {
   const [username, setUsername] = useState(profile.username);
   const [bio, setBio] = useState(profile.bio ?? "");
-  const [profilePhoto, setProfilePhoto] = useState(profile.profilePhoto ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
@@ -27,7 +26,6 @@ export default function SocialProfileEditForm({ profile, onUpdated }: Props) {
       const updated = await updateSocialProfile(profile.id, {
         username,
         bio,
-        profilePhoto,
       });
       setSuccess(true);
       onUpdated?.(updated);
@@ -59,12 +57,6 @@ export default function SocialProfileEditForm({ profile, onUpdated }: Props) {
           value={bio}
           onChange={(_n, v) => setBio(String(v))}
           rows={2}
-        />
-        <TextField
-          label="Profile Photo URL"
-          name="profilePhoto"
-          value={profilePhoto}
-          onChange={(_n, v) => setProfilePhoto(String(v))}
         />
         <div className="flex justify-end">
           <Button type="submit" disabled={saving}>

--- a/src/components/social/SocialProfileForm.tsx
+++ b/src/components/social/SocialProfileForm.tsx
@@ -14,7 +14,6 @@ export default function SocialProfileForm({ onCreated }: Props) {
   const { data: session } = useSession();
   const [username, setUsername] = useState("");
   const [bio, setBio] = useState("");
-  const [profilePhoto, setProfilePhoto] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
@@ -33,12 +32,10 @@ export default function SocialProfileForm({ onCreated }: Props) {
         userId: session.user.id,
         username,
         bio: bio || undefined,
-        profilePhoto: profilePhoto || undefined,
       });
       setSuccess("Profile created!");
       setUsername("");
       setBio("");
-      setProfilePhoto("");
       onCreated?.();
     } catch {
       setError("Failed to create profile");
@@ -64,12 +61,6 @@ export default function SocialProfileForm({ onCreated }: Props) {
           value={bio}
           onChange={(_n, v) => setBio(String(v))}
           rows={2}
-        />
-        <TextField
-          label="Profile Photo URL"
-          name="profilePhoto"
-          value={profilePhoto}
-          onChange={(_n, v) => setProfilePhoto(String(v))}
         />
         <div className="flex justify-end">
           <Button type="submit">Create Profile</Button>


### PR DESCRIPTION
## Summary
- use the user's avatar when displaying social posts
- remove separate profile photo fields from social profile forms
- provide avatarUrl from API routes
- display avatarUrl on user profile page
- update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ba26da4608324be066c2ad1966c5b