### PR TITLE
Add social profile card and integrate

### DIFF
--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -1,36 +1,55 @@
+"use client";
 import Link from "next/link";
-import { Card } from "@components/ui";
-import { Users, Activity, User } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+import { useUser } from "@hooks/useUser";
+import ProfileInfoCard from "@components/social/ProfileInfoCard";
+import ProfileSearch from "@components/social/ProfileSearch";
+import SocialFeed from "@components/social/SocialFeed";
+import { Button } from "@components/ui";
 
 export default function SocialHomePage() {
+  const { data: session } = useSession();
+  const { profile, loading } = useSocialProfile();
+  const { profile: user } = useUser();
+
+  if (!session?.user) {
+    return (
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
+        <p>Please log in to access social features.</p>
+      </main>
+    );
+  }
+
+  if (loading) {
+    return (
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
+        <p>Loading...</p>
+      </main>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-6 space-y-2">
+        <p>Create your social profile first.</p>
+        <Button asChild>
+          <Link href="/social/profile/new">Create Social Profile</Link>
+        </Button>
+      </main>
+    );
+  }
+
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 bg-background text-foreground space-y-10 pt-8 pb-20">
-      <h1 className="text-3xl font-bold">Social Hub</h1>
-      <div className="h-1 w-24 mb-6 bg-gradient-to-r from-brand-from to-brand-to rounded" />
-      <section>
-        <h2 className="text-2xl font-bold mb-4">Quick Links</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <Link href="/social/feed">
-            <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
-              <Activity className="w-5 h-5" />
-              <span>Your Feed</span>
-            </Card>
-          </Link>
-          <Link href="/social/search">
-            <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
-              <Users className="w-5 h-5" />
-              <span>Find Runners</span>
-            </Card>
-          </Link>
-          <Link href="/social/profile/edit">
-            <Card className="p-4 flex items-center gap-2 hover:bg-accent-3/10">
-              <User className="w-5 h-5" />
-              <span>Your Profile</span>
-            </Card>
-          </Link>
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-8">
+        <ProfileInfoCard profile={profile} user={user ?? undefined} isSelf />
+        <div className="max-w-3xl mx-auto">
+          <ProfileSearch />
         </div>
-      </section>
+        <div className="max-w-3xl mx-auto">
+          <SocialFeed />
+        </div>
       </main>
     </div>
   );

--- a/src/components/__tests__/ProfileInfoCard.test.tsx
+++ b/src/components/__tests__/ProfileInfoCard.test.tsx
@@ -1,0 +1,35 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ProfileInfoCard from "../social/ProfileInfoCard";
+import type { SocialProfile } from "@maratypes/social";
+import type { User } from "@maratypes/user";
+
+const profile: SocialProfile = {
+  id: "p1",
+  userId: "u1",
+  username: "runner",
+  bio: "fast",
+  profilePhoto: null,
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-02"),
+  name: "Runner",
+  runCount: 5,
+  totalDistance: 20,
+  followerCount: 3,
+  followingCount: 4,
+};
+
+const user: Pick<User, "avatarUrl" | "createdAt"> = {
+  avatarUrl: "/avatar.png",
+  createdAt: new Date("2024-01-01"),
+};
+
+describe("ProfileInfoCard", () => {
+  it("shows profile details and edit button", () => {
+    render(<ProfileInfoCard profile={profile} user={user} isSelf />);
+    expect(screen.getByRole("heading", { name: /runner/i })).toBeInTheDocument();
+    expect(screen.getByText(/5 runs/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/social/ProfileInfoCard.tsx
+++ b/src/components/social/ProfileInfoCard.tsx
@@ -1,0 +1,51 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+import type { SocialProfile } from "@maratypes/social";
+import type { User } from "@maratypes/user";
+import { Card, Button } from "@components/ui";
+
+interface Props {
+  profile: SocialProfile;
+  user?: Pick<User, "avatarUrl" | "createdAt">;
+  isSelf?: boolean;
+}
+
+export default function ProfileInfoCard({ profile, user, isSelf }: Props) {
+  const avatar = user?.avatarUrl || profile.profilePhoto || "/default_profile.png";
+  const joined = user?.createdAt ?? profile.createdAt;
+  const joinedText = new Date(joined).toLocaleDateString(undefined, {
+    month: "2-digit",
+    year: "2-digit",
+  });
+
+  return (
+    <Card className="p-4 flex gap-4 items-start">
+      <Image
+        src={avatar}
+        alt={profile.username}
+        width={64}
+        height={64}
+        className="w-16 h-16 rounded-full object-cover"
+      />
+      <div className="flex-1 space-y-1">
+        <h2 className="text-xl font-bold">{profile.name ?? profile.username}</h2>
+        <p className="text-sm text-foreground/60">
+          @{profile.username} • Joined {joinedText}
+        </p>
+        {profile.bio && <p className="text-sm text-foreground/70">{profile.bio}</p>}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm text-muted-foreground mt-2">
+          <span>{profile.runCount ?? 0} runs</span>
+          <span>{profile.totalDistance ?? 0} mi</span>
+          <span>{profile.followerCount ?? 0} followers</span>
+          <span>{profile.followingCount ?? 0} following</span>
+        </div>
+      </div>
+      {isSelf && (
+        <Button asChild size="sm" className="self-start">
+          <Link href="/social/profile/edit">Edit</Link>
+        </Button>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ProfileInfoCard` component with join date, counts, and edit link
- show own profile card, search bar, and feed on social home page
- add tests for `ProfileInfoCard`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ba3776f448324aacecb2bb8b20ea3