### PR TITLE
Add user profile card page

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useEffect, useState } from "react";
+import ProfileInfoCard from "@components/ProfileInfoCard";
+import type { UserProfile } from "@maratypes/user";
+
+interface PageProps {
+  params: { username: string };
+}
+
+export default function UserPage({ params }: PageProps) {
+  const { username } = params;
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const res = await fetch(`/api/users/${username}`);
+        if (!res.ok) throw new Error("Failed to load profile");
+        const data = await res.json();
+        setProfile(data as UserProfile);
+      } catch {
+        setError("User not found");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+  }, [username]);
+
+  return (
+    <main className="w-full px-4 sm:px-6 lg:px-8 py-6 flex justify-center">
+      {loading ? (
+        <p>Loading...</p>
+      ) : error ? (
+        <p className="text-red-600">{error}</p>
+      ) : profile ? (
+        <div className="max-w-md w-full">
+          <ProfileInfoCard profile={profile} />
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/src/components/ProfileInfoCard.tsx
+++ b/src/components/ProfileInfoCard.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import { Card } from "@components/ui";
+import DefaultAvatar from "@components/DefaultAvatar";
+import type { UserProfile } from "@maratypes/user";
+
+interface Props {
+  profile: UserProfile;
+}
+
+export default function ProfileInfoCard({ profile }: Props) {
+  return (
+    <Card className="p-6 flex flex-col items-center text-center space-y-4">
+      {profile.avatarUrl ? (
+        <Image
+          src={profile.avatarUrl}
+          alt={profile.name}
+          width={96}
+          height={96}
+          className="w-24 h-24 rounded-full object-cover"
+        />
+      ) : (
+        <DefaultAvatar
+          seed={profile.email || profile.name}
+          size={96}
+          className="w-24 h-24"
+        />
+      )}
+      <h2 className="text-2xl font-bold">{profile.name}</h2>
+      {profile.trainingLevel && (
+        <p className="text-muted-foreground capitalize">
+          {profile.trainingLevel}
+        </p>
+      )}
+      {profile.weeklyMileage && (
+        <p className="text-sm text-muted-foreground">
+          Weekly Mileage: {profile.weeklyMileage}
+          {" "}
+          {profile.defaultDistanceUnit || "miles"}
+        </p>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `ProfileInfoCard` component
- add dynamic user page at `/u/[username]` that fetches the profile and displays the new card

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c6e541ef48324ba7cf0c8ac8c8011