### PR TITLE
Improve user profile page

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,10 +1,11 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../api/auth/[...nextauth]/route";
 import type { SocialProfile, RunPost } from "@maratypes/social";
 import FollowUserButton from "@components/social/FollowUserButton";
+import ProfileInfoCard from "@components/social/ProfileInfoCard";
+import { Card } from "@components/ui";
 import { prisma } from "@lib/prisma";
 
 async function getProfileData(username: string) {
@@ -72,79 +73,49 @@ export default async function UserProfilePage({ params }: Props) {
   const session = await getServerSession(authOptions);
   const isSelf = session?.user?.id === data.userId;
 
+  const profile: SocialProfile = {
+    id: data.id,
+    userId: data.userId,
+    username: data.username,
+    bio: data.bio,
+    avatarUrl: data.avatarUrl,
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+    name: data.name,
+    runCount: data.runCount,
+    totalDistance: data.totalDistance,
+    followerCount: data.followerCount,
+    followingCount: data.followingCount,
+  };
+
   return (
-    <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8">
-        <section className="max-w-3xl mx-auto py-6">
-          <div className="p-4 space-y-6">
-            <div className="flex items-center gap-6 p-4 rounded-md bg-background border">
-              <Image
-                src={data.avatarUrl || "/default_profile.png"}
-                alt={data.username}
-                width={64}
-                height={64}
-                className="w-16 h-16 rounded-full object-cover"
-              />
-              <div>
-                <h1 className="text-2xl font-bold">{data.name ?? data.username}</h1>
-                <p className="text-sm text-foreground/60">
-                  @{data.username} • Joined{' '}
-                  {new Date(data.userCreatedAt).toLocaleDateString()}
-                </p>
-                {data.bio && <p className="text-foreground/70">{data.bio}</p>}
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 max-w-screen-lg py-8 flex flex-col lg:flex-row gap-8">
+        <section className="lg:w-2/3 order-2 lg:order-1 space-y-6">
+          <h2 className="text-xl font-semibold">Posts</h2>
+          {data.posts.length === 0 && <p>No posts yet.</p>}
+          {data.posts.map((post: RunPost) => (
+            <Card key={post.id} className="space-y-2 p-4">
+              <p className="text-base font-semibold">
+                {post.distance} mi in {post.time}
+              </p>
+              <div className="text-sm text-foreground/60">
+                {new Date(post.createdAt).toLocaleString()}
               </div>
-            </div>
-          </div>
-
-          <div className="p-4">
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 p-4 bg-muted/20 rounded-md text-center text-sm text-muted-foreground">
-              <span>{data.runCount ?? 0} runs</span>
-              <span>{data.totalDistance ?? 0} mi total</span>
-              <span>{data.followerCount ?? 0} followers</span>
-              <span>{data.followingCount ?? 0} following</span>
-            </div>
-          </div>
-
-          <div className="p-4">
-            {isSelf ? (
-              <Link href="/social/profile/edit" className="text-primary underline">
-                Edit Profile
-              </Link>
-            ) : (
-              <FollowUserButton profileId={data.id} />
-            )}
-          </div>
-
-          <div className="p-4 space-y-4">
-            <h2 className="text-xl font-semibold">Posts</h2>
-            {data.posts.length === 0 && <p>No posts yet.</p>}
-            {data.posts.map((post: RunPost) => (
-              <div key={post.id} className="border rounded-lg bg-card shadow-sm p-4 space-y-2">
-                <p className="text-base font-semibold">
-                  {post.distance} mi in {post.time}
-                </p>
-                <div className="text-sm text-foreground/60">
-                  {new Date(post.createdAt).toLocaleString()}
-                </div>
-                {post.caption && <p className="mt-2">{post.caption}</p>}
-                {post.photoUrl && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={post.photoUrl}
-                    alt="Run photo"
-                    className="mt-2 rounded-md"
-                  />
-                )}
-                <div className="text-sm text-foreground/60 mt-1">
-                  <span>{post._count?.likes ?? 0} likes</span>{" "}
-                  <span>{post._count?.comments ?? 0} comments</span>
-                </div>
+              {post.caption && <p className="mt-2">{post.caption}</p>}
+              {post.photoUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={post.photoUrl} alt="Run photo" className="mt-2 rounded-md" />
+              )}
+              <div className="text-sm text-foreground/60 mt-1">
+                <span>{post._count?.likes ?? 0} likes</span>{" "}
+                <span>{post._count?.comments ?? 0} comments</span>
               </div>
-            ))}
-          </div>
+            </Card>
+          ))}
 
           {isSelf && (
-            <div className="p-4 border rounded-md bg-background space-y-2">
+            <Card className="space-y-2 p-4">
               <h2 className="text-xl font-semibold">Followers</h2>
               <ul className="list-disc ml-6">
                 {data.followers.map((f: SocialProfile) => (
@@ -168,9 +139,17 @@ export default async function UserProfilePage({ params }: Props) {
               <p className="text-sm text-foreground/60">
                 Likes made: {data.likeActivity} | Comments made: {data.commentActivity}
               </p>
-            </div>
+            </Card>
           )}
         </section>
+        <aside className="lg:w-1/3 order-1 lg:order-2 space-y-6">
+          <ProfileInfoCard
+            profile={profile}
+            user={{ avatarUrl: data.avatarUrl ?? undefined, createdAt: data.userCreatedAt }}
+            isSelf={isSelf}
+          />
+          {!isSelf && <FollowUserButton profileId={data.id} />}
+        </aside>
       </main>
     </div>
   );

--- a/src/components/__tests__/SocialProfileForm.test.tsx
+++ b/src/components/__tests__/SocialProfileForm.test.tsx
@@ -7,6 +7,10 @@ import SocialProfileForm from "../social/SocialProfileForm";
 import { createSocialProfile } from "@lib/api/social";
 import { useSession } from "next-auth/react";
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
 jest.mock("@lib/api/social");
 jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
 


### PR DESCRIPTION
## Summary
- use `<ProfileInfoCard>` on `/u/[username]`
- restyle the page similar to social feed layout
- mock router in SocialProfileForm tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7fd830b483248a16b067cbddf739