### PR TITLE
Fix RunPost type for post count data

### DIFF
--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -26,6 +26,10 @@ export interface RunPost {
   socialProfile?: SocialProfile & { user?: { avatarUrl?: string } };
   likeCount?: number;
   commentCount?: number;
+  _count?: {
+    likes: number;
+    comments: number;
+  };
 }
 
 export interface Follow {


### PR DESCRIPTION
## Summary
- include `_count` in `RunPost` maratype so API data including like/comment counts type-checks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c91a1f68883248c2a680040ec0321