### PR TITLE
Add photo upload and modal viewer

### DIFF
--- a/src/components/social/CreateSocialPost.tsx
+++ b/src/components/social/CreateSocialPost.tsx
@@ -3,8 +3,8 @@ import { useState, FormEvent, useEffect } from "react";
 import { createPost } from "@lib/api/social";
 import { listRuns } from "@lib/api/run";
 import { useSocialProfile } from "@hooks/useSocialProfile";
-import { Card, Button } from "@components/ui";
-import { TextField, TextAreaField, SelectField } from "@components/ui/FormField";
+import { Card, Button, PhotoUpload } from "@components/ui";
+import { TextAreaField, SelectField } from "@components/ui/FormField";
 import { getRunName } from "@utils/running/getRunName";
 import type { Run } from "@maratypes/run";
 
@@ -100,12 +100,7 @@ export default function CreateSocialPost({ onCreated }: Props) {
           onChange={(_n, v) => setCaption(String(v))}
           rows={2}
         />
-        <TextField
-          label="Photo URL"
-          name="photoUrl"
-          value={photoUrl}
-          onChange={(_n, v) => setPhotoUrl(String(v))}
-        />
+        <PhotoUpload value={photoUrl} onChange={(url) => setPhotoUrl(url)} />
         <div className="flex justify-end">
           <Button type="submit" size="sm">
             Post

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -7,7 +7,7 @@ import { useSocialProfile } from "@hooks/useSocialProfile";
 import CreateSocialPost from "@components/social/CreateSocialPost";
 import LikeButton from "@components/social/LikeButton";
 import CommentSection from "@components/social/CommentSection";
-import { Button } from "@components/ui";
+import { Button, Dialog, DialogContent } from "@components/ui";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -16,6 +16,7 @@ export default function SocialFeed() {
   const { profile, loading: profileLoading } = useSocialProfile();
   const [posts, setPosts] = useState<RunPost[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
   const fetchFeed = async () => {
     if (!session?.user?.id) return;
@@ -85,7 +86,8 @@ export default function SocialFeed() {
             <img
               src={post.photoUrl}
               alt="Run photo"
-              className="mt-2 rounded-md"
+              className="mt-2 rounded-md h-64 w-full object-cover cursor-pointer"
+              onClick={() => setSelectedImage(post.photoUrl!)}
             />
           )}
           <LikeButton
@@ -96,6 +98,14 @@ export default function SocialFeed() {
           <CommentSection postId={post.id} />
         </div>
       ))}
+      <Dialog open={!!selectedImage} onOpenChange={(o) => !o && setSelectedImage(null)}>
+        <DialogContent className="p-0 max-w-3xl">
+          {selectedImage && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={selectedImage} alt="Run photo" className="w-full h-full object-contain" />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -25,3 +25,4 @@ export * from './radio-group';
 export * from './slider';
 export * from './select';
 export { default as AvatarUpload } from './avatar-upload';
+export { default as PhotoUpload } from "./photo-upload";

--- a/src/components/ui/photo-upload.tsx
+++ b/src/components/ui/photo-upload.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRef } from "react";
+import { Button } from "@components/ui";
+import { uploadImage } from "@lib/api/upload";
+
+interface PhotoUploadProps {
+  value?: string;
+  onChange?: (url: string) => void;
+  disabled?: boolean;
+}
+
+export default function PhotoUpload({ value, onChange, disabled }: PhotoUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const url = await uploadImage(file);
+    onChange?.(url);
+  };
+
+  return (
+    <div className="flex items-center space-x-4">
+      {value && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={value}
+          alt="Preview"
+          className="h-20 w-20 rounded-md object-cover"
+        />
+      )}
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled}
+        >
+          Upload Photo
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={handleFileChange}
+          className="hidden"
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api/upload.ts
+++ b/src/lib/api/upload.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+export const uploadImage = async (file: File): Promise<string> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await axios.post("/api/upload", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return res.data.url as string;
+};


### PR DESCRIPTION
## Summary
- add generic `uploadImage` API helper
- create `PhotoUpload` component
- allow photo upload in social posts
- standardize feed photo size and add dialog for viewing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cb8031e2483249264a183f5246c42