### PR TITLE
Prefix run names with plan

### DIFF
--- a/src/components/runs/WeeklyRuns.tsx
+++ b/src/components/runs/WeeklyRuns.tsx
@@ -114,7 +114,7 @@ export default function WeeklyRuns() {
           distance: run.mileage,
           distanceUnit: run.unit,
           userId: plan.userId,
-          name: `Week ${weekIndex + 1} - ${run.type}`,
+          name: `${plan.name} - Week ${weekIndex + 1} - ${run.type}`,
         });
       }
       setPlan(updated);


### PR DESCRIPTION
## Summary
- add plan name to run titles when logging runs from weekly plan

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbbb17e9c8324aef2c402340eee38