### PR TITLE
Add createdAt fields to User type

### DIFF
--- a/src/maratypes/user.ts
+++ b/src/maratypes/user.ts
@@ -45,4 +45,7 @@ export interface User {
 
   shoes?: Shoe[];
   defaultShoeId?: string;
+
+  createdAt?: Date;
+  updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary
- keep User type aligned with Prisma schema
- add `createdAt` and `updatedAt` properties to `User`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cbc0319e48324870efeb0103102c9