### PR TITLE
refactor: unify theme colors

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -78,7 +78,7 @@ const LoginPage: React.FC = () => {
     <div className="min-h-screen flex flex-col">
       <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <h1 className="text-3xl font-bold text-center">Login</h1>
-        {error && <p className="text-red-500 text-center">{error}</p>}
+        {error && <p className="text-brand-orange-dark text-center">{error}</p>}
         <div className="flex justify-center">
           <button
             type="button"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,9 +18,9 @@ export default function Landing() {
     <div className="min-h-screen bg-background">
       {/* Hero Section */}
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-white/60 dark:bg-white/5 backdrop-blur-sm z-0"></div>
+        <div className="absolute inset-0 bg-background/60 backdrop-blur-sm z-0"></div>
         <div className="w-full px-4 sm:px-6 lg:px-8 py-20 relative">
-          <div className="w-full text-center bg-red">
+          <div className="w-full text-center">
             <Badge className="mb-6 bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] text-white border-0">
               Powered by Advanced AI Training Science
             </Badge>
@@ -96,7 +96,7 @@ export default function Landing() {
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-lg flex items-center justify-center mb-6 ring-2 ring-white/40 dark:ring-white/10">
                 <Brain className="w-6 h-6 text-white" />
               </div>
@@ -110,7 +110,7 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-lg flex items-center justify-center mb-6 ring-2 ring-white/40 dark:ring-white/10">
                 <Target className="w-6 h-6 text-white" />
               </div>
@@ -124,7 +124,7 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-lg flex items-center justify-center mb-6 ring-2 ring-white/40 dark:ring-white/10">
                 <Watch className="w-6 h-6 text-white" />
               </div>
@@ -137,7 +137,7 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-lg flex items-center justify-center mb-6 ring-2 ring-white/40 dark:ring-white/10">
                 <TrendingUp className="w-6 h-6 text-white" />
               </div>
@@ -151,7 +151,7 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-lg flex items-center justify-center mb-6 ring-2 ring-white/40 dark:ring-white/10">
                 <Clock className="w-6 h-6 text-white" />
               </div>
@@ -162,7 +162,7 @@ export default function Landing() {
               </p>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-lg flex items-center justify-center mb-6 ring-2 ring-white/40 dark:ring-white/10">
                 <Award className="w-6 h-6 text-white" />
               </div>
@@ -179,7 +179,7 @@ export default function Landing() {
       {/* Science Section */}
       <section
         id="science"
-        className="py-20 bg-white/50 dark:bg-white/5 backdrop-blur"
+        className="py-20 bg-background/50 dark:bg-background/20 backdrop-blur"
       >
         <div className="w-full px-4 sm:px-6 lg:px-8">
           <div className="w-full text-center">
@@ -196,7 +196,7 @@ export default function Landing() {
             </p>
 
             <div className="grid md:grid-cols-2 gap-8">
-              <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300 text-left">
+              <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300 text-left">
                 <h3 className="text-2xl font-semibold mb-4">
                   Jack Daniels&apos; VDOT
                 </h3>
@@ -210,7 +210,7 @@ export default function Landing() {
                 </div>
               </Card>
 
-              <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300 text-left">
+              <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300 text-left">
                 <h3 className="text-2xl font-semibold mb-4">
                   ACWR Load Management
                 </h3>
@@ -245,7 +245,7 @@ export default function Landing() {
           </div>
 
           <div className="grid md:grid-cols-3 gap-8">
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="flex items-center mb-6">
                 <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-full flex items-center justify-center text-white font-bold ring-2 ring-white/40 dark:ring-white/10">
                   S
@@ -267,7 +267,7 @@ export default function Landing() {
               </div>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="flex items-center mb-6">
                 <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-full flex items-center justify-center text-white font-bold ring-2 ring-white/40 dark:ring-white/10">
                   M
@@ -289,7 +289,7 @@ export default function Landing() {
               </div>
             </Card>
 
-            <Card className="p-8 border border-muted bg-white/90 dark:bg-white/10 shadow-xl transition-all duration-300">
+            <Card className="p-8 border border-muted bg-background/90 dark:bg-background/40 shadow-xl transition-all duration-300">
               <div className="flex items-center mb-6">
                 <div className="w-12 h-12 bg-gradient-to-br from-[var(--brand-purple)] to-[var(--brand-blue)] rounded-full flex items-center justify-center text-white font-bold ring-2 ring-white/40 dark:ring-white/10">
                   A
@@ -314,7 +314,7 @@ export default function Landing() {
       </section>
 
       {/* Final CTA Section */}
-      <section className="py-20 bg-white/80 dark:bg-white/5 backdrop-blur-sm text-foreground relative overflow-hidden">
+      <section className="py-20 bg-background/80 dark:bg-background/20 backdrop-blur-sm text-foreground relative overflow-hidden">
         <div className="w-full px-4 sm:px-6 lg:px-8 relative">
           <div className="w-full text-center">
             <h2 className="text-4xl md:text-6xl font-bold mb-6">
@@ -343,7 +343,7 @@ export default function Landing() {
                 <Button
                   variant="outline"
                   size="lg"
-                  className="border-foreground text-foreground hover:bg-muted/20 dark:border-white dark:text-white dark:hover:bg-white/10 text-lg px-8 py-6"
+                  className="border-foreground text-foreground hover:bg-muted/20 dark:border-foreground dark:text-foreground dark:hover:bg-foreground/10 text-lg px-8 py-6"
                 >
                   <PlayCircle className="mr-2 h-5 w-5" />
                   See How It Works

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -88,7 +88,7 @@ export default function UserPage() {
   }
   if (error) {
     return (
-      <main className="w-full px-4 sm:px-6 lg:px-8 py-6 text-red-600">
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-6 text-brand-orange-dark">
         {error}
       </main>
     );

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -51,9 +51,9 @@ export default function SignupPage() {
       <section className="relative py-20 overflow-hidden flex items-center justify-center">
         <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" />
         <div className="relative w-full px-4 sm:px-6 lg:px-8 flex justify-center">
-          <Card className="w-full max-w-md p-8 bg-white/90 dark:bg-white/10 shadow-xl space-y-6">
+          <Card className="w-full max-w-md p-8 bg-background/90 dark:bg-background/40 shadow-xl space-y-6">
             <h1 className="text-3xl font-bold text-center">Create Your Account</h1>
-            {error && <p className="text-red-500 text-center">{error}</p>}
+            {error && <p className="text-brand-orange-dark text-center">{error}</p>}
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="name">Name</Label>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Footer() {
   return (
-    <footer className="py-8 text-center text-foreground/60 text-sm bg-white dark:bg-[#0f172a] border-t border-muted dark:border-white/10 relative z-10">
+    <footer className="py-8 text-center text-foreground/60 text-sm bg-background border-t border-muted relative z-10">
       <div className="w-full px-4 sm:px-6 lg:px-8 space-y-2">
         <Image
           src="/maratron-name.svg"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -45,7 +45,7 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="bg-white dark:bg-[#111827] border-b border-muted dark:border-white/10 backdrop-blur-sm relative z-20">
+    <nav className="bg-background border-b border-muted backdrop-blur-sm relative z-20">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex items-center justify-between py-6">
         {/* Left: Logo and links */}
         <div className="flex items-center">

--- a/src/components/profile/UserProfileForm.tsx
+++ b/src/components/profile/UserProfileForm.tsx
@@ -59,7 +59,7 @@ export default function UserProfileForm({
       </div>
 
       {validationErrors.length > 0 && (
-        <div className="mb-4 p-3 bg-red-700 bg-opacity-10 text-red-400 rounded">
+        <div className="mb-4 p-3 bg-brand-orange-dark/10 text-brand-orange-dark rounded">
           <ul className="list-disc list-inside">
             {validationErrors.map((msg, i) => (
               <li key={i}>{msg}</li>

--- a/src/components/runs/RunForm.tsx
+++ b/src/components/runs/RunForm.tsx
@@ -171,7 +171,7 @@ const RunForm: React.FC<RunFormProps> = ({ onSubmit }) => {
       {errors.length > 0 && (
         <div className="space-y-1 mb-4">
           {errors.map((err, i) => (
-            <p key={i} className="text-red-600 text-sm">
+            <p key={i} className="text-brand-orange-dark text-sm">
               {err}
             </p>
           ))}

--- a/src/components/runs/RunModal.tsx
+++ b/src/components/runs/RunModal.tsx
@@ -13,7 +13,7 @@ export default function RunModal({ run, onClose }: RunModalProps) {
   if (!run) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/50">
       <Card className="relative w-1/2 bg-background p-6 rounded-lg shadow-lg">
         <button
           aria-label="Close"

--- a/src/components/shoes/ShoeForm.tsx
+++ b/src/components/shoes/ShoeForm.tsx
@@ -125,7 +125,7 @@ const ShoeForm: React.FC<ShoeFormProps> = ({ onSubmit, initialData }) => {
       {errors.length > 0 && (
         <div className="space-y-1 mb-4">
           {errors.map((err, i) => (
-            <p key={i} className="text-red-600 text-sm">
+            <p key={i} className="text-brand-orange-dark text-sm">
               {err}
             </p>
           ))}

--- a/src/components/social/CreateSocialPost.tsx
+++ b/src/components/social/CreateSocialPost.tsx
@@ -73,7 +73,7 @@ export default function CreateSocialPost({ onCreated }: Props) {
   return (
     <Card className="p-4 mb-6">
       <h3 className="text-lg font-semibold mb-2">Share a Run</h3>
-      {error && <p className="text-red-600 mb-2">{error}</p>}
+      {error && <p className="text-brand-orange-dark mb-2">{error}</p>}
       {success && <p className="text-primary mb-2">{success}</p>}
       <form onSubmit={handleSubmit} className="space-y-2">
         {loadingRuns ? (

--- a/src/components/social/SocialProfileEditForm.tsx
+++ b/src/components/social/SocialProfileEditForm.tsx
@@ -41,7 +41,7 @@ export default function SocialProfileEditForm({ profile, onUpdated }: Props) {
   return (
     <Card className="p-6 w-full max-w-md">
       <h2 className="text-2xl font-semibold mb-4">Edit Social Profile</h2>
-      {error && <p className="text-red-600 mb-2">{error}</p>}
+      {error && <p className="text-brand-orange-dark mb-2">{error}</p>}
       {success && <p className="text-primary mb-2">Profile updated!</p>}
       <form onSubmit={handleSubmit} className="space-y-4">
         <TextField

--- a/src/components/social/SocialProfileForm.tsx
+++ b/src/components/social/SocialProfileForm.tsx
@@ -49,7 +49,7 @@ export default function SocialProfileForm({ onCreated }: Props) {
   return (
     <Card className="p-6 w-full max-w-md">
       <h2 className="text-2xl font-semibold mb-4">Create Social Profile</h2>
-      {error && <p className="text-red-600 mb-2">{error}</p>}
+      {error && <p className="text-brand-orange-dark mb-2">{error}</p>}
       {success && <p className="text-primary mb-2">{success}</p>}
       <form onSubmit={handleSubmit} className="space-y-4">
         <TextField

--- a/src/components/training/TrainingPlansList.tsx
+++ b/src/components/training/TrainingPlansList.tsx
@@ -101,7 +101,7 @@ export default function TrainingPlansList() {
             {plan.id && (
               <Button
                 onClick={() => deletePlan(plan.id!)}
-                className="text-sm px-2 py-1 bg-red-600 hover:bg-red-700"
+                className="text-sm px-2 py-1 bg-brand-orange-dark hover:bg-brand-orange"
               >
                 Delete
               </Button>

--- a/src/components/ui/FormField/CheckboxGroupField.tsx
+++ b/src/components/ui/FormField/CheckboxGroupField.tsx
@@ -27,7 +27,7 @@ const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
     <div className={`space-y-1 ${className}`}>
       <Label htmlFor={name} className="block font-medium">
         {label}
-        {inputProps.required && <span className="text-red-500 ml-1">*</span>}
+        {inputProps.required && <span className="text-brand-orange-dark ml-1">*</span>}
       </Label>
 
       {editing ? (

--- a/src/components/ui/FormField/SelectField.tsx
+++ b/src/components/ui/FormField/SelectField.tsx
@@ -27,7 +27,7 @@ const SelectField: React.FC<SelectFieldProps> = ({
     <div className={`space-y-1 ${className}`}>
       <Label htmlFor={name} className="block font-medium">
         {label}
-        {selectProps.required && <span className="text-red-500 ml-1">*</span>}
+        {selectProps.required && <span className="text-brand-orange-dark ml-1">*</span>}
       </Label>
 
       {editing ? (

--- a/src/components/ui/FormField/TextAreaField.tsx
+++ b/src/components/ui/FormField/TextAreaField.tsx
@@ -25,7 +25,7 @@ const TextAreaField: React.FC<TextAreaFieldProps> = ({
     <div className={`space-y-1 ${className}`}>
       <Label htmlFor={name} className="block font-medium">
         {label}
-        {props.required && <span className="text-red-500 ml-1">*</span>}
+        {props.required && <span className="text-brand-orange-dark ml-1">*</span>}
       </Label>
 
       {editing ? (

--- a/src/components/ui/FormField/TextField.tsx
+++ b/src/components/ui/FormField/TextField.tsx
@@ -26,7 +26,7 @@ const TextField: React.FC<TextFieldProps> = ({
     <div className={`space-y-1 ${className}`}>
       <Label htmlFor={name} className="block font-medium">
         {label}
-        {inputProps.required && <span className="text-red-500 ml-1">*</span>}
+        {inputProps.required && <span className="text-brand-orange-dark ml-1">*</span>}
       </Label>
 
       {editing ? (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
         default: "bg-primary text-foreground hover:bg-primary/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-foreground",
         secondary: "bg-secondary text-foreground hover:bg-secondary/80",
-        destructive: "bg-red-600 text-foreground hover:bg-red-700",
+        destructive: "bg-brand-orange-dark text-foreground hover:bg-brand-orange",
         ghost: "hover:bg-accent/20",
       },
       size: {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,7 +12,7 @@ export const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
+      "fixed inset-0 z-50 bg-foreground/50 backdrop-blur-sm",
       className
     )}
     {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -12,7 +12,7 @@ export const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/50", className)}
+    className={cn("fixed inset-0 z-50 bg-foreground/50", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- use theme colors for Navbar/Footer
- apply global colors for overlays and cards
- adjust form error styles and destructive button variant
- use brand colors for delete buttons and messages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cce7d64148324bd06b57d8dad9c6a