### PR TITLE
style: unify form field styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,11 +54,12 @@ p {
   line-height: 1.6;
 }
 
-input,
-select,
-textarea {
-  @apply bg-accent-2/10 text-foreground border border-accent-2 rounded px-2 py-1
-         focus:outline-none focus:ring-2 focus:ring-accent-2;
+@layer base {
+  input,
+  select,
+  textarea {
+    @apply border border-accent-2 rounded-md bg-accent-2/10 px-3 py-2 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent-2 disabled:cursor-not-allowed disabled:opacity-50;
+  }
 }
 
 button {


### PR DESCRIPTION
## Summary
- use Tailwind base layer to normalize `<input>`, `<select>` and `<textarea>` styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d86092a908324b467edc93da72bdb