### PR TITLE
Add loading spinner component

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,9 +1,9 @@
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@components/ui";
 
 export default function Loading() {
   return (
     <div className="flex h-screen w-full items-center justify-center">
-      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <Spinner className="h-8 w-8" />
       <span className="sr-only">Loading...</span>
     </div>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { signIn, useSession } from "next-auth/react";
+import { Spinner } from "@components/ui";
 
 const LoginPage: React.FC = () => {
   const { data: session, status } = useSession();
@@ -51,7 +52,9 @@ const LoginPage: React.FC = () => {
   if (status === "loading") {
     return (
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
-        <h1 className="text-2xl">Loading...</h1>
+        <div className="flex justify-center py-4">
+          <Spinner className="h-4 w-4" />
+        </div>
       </main>
     );
   }

--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -7,7 +7,7 @@ import { getRunningPlan, updateRunningPlan } from "@lib/api/plan";
 import { assignDatesToPlan } from "@utils/running/planDates";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import RunningPlanDisplay from "@components/training/RunningPlanDisplay";
-import { Button } from "@components/ui";
+import { Button, Spinner } from "@components/ui";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -50,7 +50,9 @@ export default function PlanPage({ params }: PageProps) {
   if (status === "loading" || loading) {
     return (
       <main className="w-full px-4 sm:px-6 lg:px-8 py-4">
-        Loading...
+        <div className="flex justify-center py-4">
+          <Spinner className="h-5 w-5" />
+        </div>
       </main>
     );
   }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import { Spinner } from "@components/ui";
 import UserForm from "@components/profile/UserProfileForm";
 import { User } from "@maratypes/user";
 import { getUser, updateUser } from "@lib/api/user/user";
@@ -61,7 +62,11 @@ export default function UserPage() {
   // Not authenticated
   if (status === "loading") {
     return (
-      <main className="w-full px-4 sm:px-6 lg:px-8 py-6">Loading...</main>
+      <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex justify-center py-4">
+          <Spinner className="h-4 w-4" />
+        </div>
+      </main>
     );
   }
   if (status !== "authenticated" || !session.user) {
@@ -82,7 +87,9 @@ export default function UserPage() {
   if (loading) {
     return (
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
-        Loading profile...
+        <div className="flex justify-center py-4">
+          <Spinner className="h-4 w-4" />
+        </div>
       </main>
     );
   }

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -6,7 +6,7 @@ import { useUser } from "@hooks/useUser";
 import ProfileInfoCard from "@components/social/ProfileInfoCard";
 import ProfileSearch from "@components/social/ProfileSearch";
 import SocialFeed from "@components/social/SocialFeed";
-import { Button } from "@components/ui";
+import { Button, Spinner } from "@components/ui";
 
 export default function SocialHomePage() {
   const { data: session } = useSession();
@@ -24,7 +24,9 @@ export default function SocialHomePage() {
   if (loading) {
     return (
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6">
-        <p>Loading...</p>
+        <div className="flex justify-center py-4">
+          <Spinner className="h-4 w-4" />
+        </div>
       </main>
     );
   }

--- a/src/app/social/profile/edit/page.tsx
+++ b/src/app/social/profile/edit/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import SocialProfileEditForm from "@components/social/SocialProfileEditForm";
+import { Spinner } from "@components/ui";
 
 export default function EditSocialProfilePage() {
   const { profile, loading } = useSocialProfile();
 
-  if (loading) return <p className="w-full px-4 py-6">Loading...</p>;
+  if (loading)
+    return (
+      <div className="w-full px-4 py-6 flex justify-center">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (!profile) return <p className="w-full px-4 py-6">Profile not found.</p>;
 
   return (

--- a/src/components/AuthTest.tsx
+++ b/src/components/AuthTest.tsx
@@ -2,6 +2,7 @@
 "use client";
 import React, { useState, FormEvent } from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
+import { Spinner } from "@components/ui";
 
 const AuthTest: React.FC = () => {
   const { data: session, status } = useSession();
@@ -28,7 +29,11 @@ const AuthTest: React.FC = () => {
   };
 
   if (status === "loading") {
-    return <div>Loading...</div>;
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   }
 
   return (

--- a/src/components/runs/RecentRuns.tsx
+++ b/src/components/runs/RecentRuns.tsx
@@ -6,6 +6,7 @@ import { listRuns } from "@lib/api/run";
 import { getRunName } from "@utils/running/getRunName";
 import type { Run } from "@maratypes/run";
 import RunModal from "@components/runs/RunModal";
+import { Spinner } from "@components/ui";
 
 export default function RecentRuns() {
   const { data: session } = useSession();
@@ -36,7 +37,12 @@ export default function RecentRuns() {
     fetchRuns();
   }, [session?.user?.id]);
 
-  if (loading) return <p className="text-foreground/60">Loading runs...</p>;
+  if (loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (runs.length === 0)
     return <p className="text-foreground/60">No runs recorded yet.</p>;
 

--- a/src/components/runs/RunForm.tsx
+++ b/src/components/runs/RunForm.tsx
@@ -11,7 +11,7 @@ import { useUser } from "@hooks/useUser";
 import { listShoes } from "@lib/api/shoe";
 import { getRunName } from "@utils/running/getRunName";
 
-import { Card, Button } from "@components/ui";
+import { Card, Button, Spinner } from "@components/ui";
 import {
   TextField,
   SelectField,
@@ -161,7 +161,12 @@ const RunForm: React.FC<RunFormProps> = ({ onSubmit }) => {
     }
   };
 
-  if (status === "loading" || profileLoading) return <div>Loading...</div>;
+  if (status === "loading" || profileLoading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
 
   return (
     <Card className="p-6 w-full">

--- a/src/components/runs/RunsList.tsx
+++ b/src/components/runs/RunsList.tsx
@@ -6,6 +6,7 @@ import { listRuns } from "@lib/api/run";
 import { getRunName } from "@utils/running/getRunName";
 import type { Run } from "@maratypes/run";
 import RunModal from "@components/runs/RunModal";
+import { Spinner } from "@components/ui";
 
 export default function RunsList() {
   const { data: session } = useSession();
@@ -36,7 +37,12 @@ export default function RunsList() {
     fetchRuns();
   }, [session?.user?.id]);
 
-  if (loading) return <p className="text-foreground/60">Loading runs...</p>;
+  if (loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (runs.length === 0)
     return <p className="text-foreground/60">No runs recorded yet.</p>;
 

--- a/src/components/runs/WeeklyRuns.tsx
+++ b/src/components/runs/WeeklyRuns.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { listRunningPlans, updateRunningPlan } from "@lib/api/plan";
 import { createRun } from "@lib/api/run";
-import { Card, Select, SelectTrigger, SelectContent, SelectItem, SelectValue, Checkbox, Progress } from "@components/ui";
+import { Card, Select, SelectTrigger, SelectContent, SelectItem, SelectValue, Checkbox, Progress, Spinner } from "@components/ui";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import { assignDatesToPlan } from "@utils/running/planDates";
 import { calculateDurationFromPace } from "@utils/running/calculateDuration";
@@ -43,7 +43,12 @@ export default function WeeklyRuns() {
     fetchPlan();
   }, [session?.user?.id, refresh]);
 
-  if (loading) return <p className="text-foreground/60">Loading...</p>;
+  if (loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (!plan) return <p className="text-foreground/60">No active plan.</p>;
 
   let weekIndex: number;

--- a/src/components/shoes/CreateShoe.tsx
+++ b/src/components/shoes/CreateShoe.tsx
@@ -6,6 +6,7 @@ import { createShoe } from "@lib/api/shoe";
 import { Shoe } from "@maratypes/shoe";
 import { useSession } from "next-auth/react";
 import { updateUser } from "@lib/api/user/user";
+import { Spinner } from "@components/ui";
 
 const CreateShoe: React.FC = () => {
   const { data: session, status } = useSession();
@@ -35,7 +36,12 @@ const CreateShoe: React.FC = () => {
     }
   };
 
-  if (status === "loading") return <div>Loading...</div>;
+  if (status === "loading")
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
 
   return (
     <div>

--- a/src/components/shoes/ShoeForm.tsx
+++ b/src/components/shoes/ShoeForm.tsx
@@ -7,7 +7,7 @@ import isYupValidationError from "@lib/utils/validation/isYupValidationError";
 import { useSession } from "next-auth/react";
 import { useUser } from "@hooks/useUser";
 
-import { Card, Button } from "@components/ui";
+import { Card, Button, Spinner } from "@components/ui";
 import {
   TextField,
   SelectField,
@@ -115,7 +115,12 @@ const ShoeForm: React.FC<ShoeFormProps> = ({ onSubmit, initialData }) => {
     }
   };
 
-  if (status === "loading") return <div>Loading...</div>;
+  if (status === "loading")
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
 
   return (
     <Card className="p-6 w-full">

--- a/src/components/shoes/ShoesList.tsx
+++ b/src/components/shoes/ShoesList.tsx
@@ -6,7 +6,7 @@ import { listShoes } from "@lib/api/shoe";
 import { updateUser } from "@lib/api/user/user";
 import { useUser } from "@hooks/useUser";
 import type { Shoe } from "@maratypes/shoe";
-import { Card, Button } from "@components/ui";
+import { Card, Button, Spinner } from "@components/ui";
 
 export default function ShoesList() {
   const { data: session } = useSession();
@@ -50,7 +50,12 @@ export default function ShoesList() {
     }
   };
 
-  if (loading) return <p className="text-foreground/60">Loading shoes...</p>;
+  if (loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (shoes.length === 0)
     return <p className="text-foreground/60">No shoes added.</p>;
 

--- a/src/components/social/CommentSection.tsx
+++ b/src/components/social/CommentSection.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, FormEvent, useCallback } from "react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import { listComments, addComment } from "@lib/api/social";
 import type { Comment } from "@maratypes/social";
-import { Button, Input } from "@components/ui";
+import { Button, Input, Spinner } from "@components/ui";
 import Image from "next/image";
 import { MessageCircle } from "lucide-react";
 
@@ -71,7 +71,9 @@ export default function CommentSection({
       {open && (
         <>
           {loading ? (
-            <p className="text-sm text-foreground/60">Loading comments...</p>
+            <div className="flex justify-center py-2">
+              <Spinner className="h-3 w-3" />
+            </div>
           ) : (
             comments.map((c) => (
               <div key={c.id} className="flex items-start gap-2 text-sm">

--- a/src/components/social/CreateSocialPost.tsx
+++ b/src/components/social/CreateSocialPost.tsx
@@ -3,7 +3,7 @@ import { useState, FormEvent, useEffect } from "react";
 import { createPost } from "@lib/api/social";
 import { listRuns } from "@lib/api/run";
 import { useSocialProfile } from "@hooks/useSocialProfile";
-import { Card, Button, PhotoUpload } from "@components/ui";
+import { Card, Button, PhotoUpload, Spinner } from "@components/ui";
 import { TextAreaField, SelectField } from "@components/ui/FormField";
 import { getRunName } from "@utils/running/getRunName";
 import type { Run } from "@maratypes/run";
@@ -77,7 +77,9 @@ export default function CreateSocialPost({ onCreated }: Props) {
       {success && <p className="text-primary mb-2">{success}</p>}
       <form onSubmit={handleSubmit} className="space-y-2">
         {loadingRuns ? (
-          <p>Loading runs...</p>
+          <div className="flex justify-center py-2">
+            <Spinner className="h-4 w-4" />
+          </div>
         ) : runs.length === 0 ? (
           <p>No recent runs found.</p>
         ) : (

--- a/src/components/social/ProfileSearch.tsx
+++ b/src/components/social/ProfileSearch.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, FormEvent } from "react";
 import axios from "axios";
 import { useSession } from "next-auth/react";
 import type { SocialProfile } from "@maratypes/social";
-import { Input, Button, Card } from "@components/ui";
+import { Input, Button, Card, Spinner } from "@components/ui";
 import FollowUserButton from "@components/social/FollowUserButton";
 import Image from "next/image";
 
@@ -66,7 +66,12 @@ export default function ProfileSearch() {
 
 
   if (!session?.user?.id) return <p>Please log in to search.</p>;
-  if (loading) return <p className="text-foreground/60">Loading...</p>;
+  if (loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (!myProfileId)
     return (
       <div className="space-y-2">

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -7,7 +7,7 @@ import { useSocialProfile } from "@hooks/useSocialProfile";
 import CreateSocialPost from "@components/social/CreateSocialPost";
 import LikeButton from "@components/social/LikeButton";
 import CommentSection from "@components/social/CommentSection";
-import { Button, Dialog, DialogContent } from "@components/ui";
+import { Button, Dialog, DialogContent, Spinner } from "@components/ui";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -38,7 +38,12 @@ export default function SocialFeed() {
   }, [session?.user?.id]);
 
   if (!session?.user?.id) return <p>Please log in to view your feed.</p>;
-  if (profileLoading || loading) return <p className="text-foreground/60">Loading feed...</p>;
+  if (profileLoading || loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (!profile)
     return (
       <div className="space-y-2">

--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { useUser } from "@hooks/useUser";
 import { TrainingLevel } from "@maratypes/user";
 import ToggleSwitch from "@components/ToggleSwitch";
+import { Spinner } from "@components/ui";
 import RunningPlanDisplay from "./RunningPlanDisplay";
 import {
   generate5kPlan,
@@ -148,7 +149,9 @@ const [targetDistance, setTargetDistance] = useState<number>(
         Generate Your Running Plan
       </h1>
       {loading ? (
-        <p className="text-center">Loading user profile...</p>
+        <div className="flex justify-center py-4">
+          <Spinner className="h-5 w-5" />
+        </div>
       ) : (
         <form onSubmit={handleGenerate} className="space-y-4">
           {/* Weeks */}

--- a/src/components/training/TrainingPlansList.tsx
+++ b/src/components/training/TrainingPlansList.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { listRunningPlans, updateRunningPlan, deleteRunningPlan } from "@lib/api/plan";
 import type { RunningPlan } from "@maratypes/runningPlan";
-import { Card, Button } from "@components/ui";
+import { Card, Button, Spinner } from "@components/ui";
 
 export default function TrainingPlansList() {
   const { data: session } = useSession();
@@ -66,7 +66,12 @@ export default function TrainingPlansList() {
     }
   };
 
-  if (loading) return <p className="text-foreground/60">Loading plans...</p>;
+  if (loading)
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
   if (plans.length === 0)
     return <p className="text-foreground/60">No plans saved.</p>;
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -26,3 +26,4 @@ export * from './slider';
 export * from './select';
 export { default as AvatarUpload } from './avatar-upload';
 export { default as PhotoUpload } from "./photo-upload";
+export * from './spinner';

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,18 @@
+import { Loader2 } from "lucide-react";
+import { cn } from "@lib/utils/cn";
+import * as React from "react";
+
+export type SpinnerProps = React.ComponentPropsWithoutRef<typeof Loader2>;
+
+const Spinner = React.forwardRef<SVGSVGElement, SpinnerProps>(
+  ({ className, ...props }, ref) => (
+    <Loader2
+      ref={ref}
+      {...props}
+      className={cn("h-5 w-5 animate-spin text-muted-foreground", className)}
+    />
+  )
+);
+Spinner.displayName = "Spinner";
+
+export { Spinner };


### PR DESCRIPTION
## Summary
- add `Spinner` component for consistent loading visuals
- use `Spinner` across pages and components instead of plain text
- rename root `loading.js` to `loading.tsx` to use the new component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d998760ec8324aff3855a10fad3e8