### PR TITLE
Auto-activate first training plan

### DIFF
--- a/src/app/api/running-plans/route.ts
+++ b/src/app/api/running-plans/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
 
     const count = await prisma.runningPlan.count({ where: { userId } });
     const defaultName = `Training Plan ${count + 1}`;
+    const isFirstPlan = count === 0;
 
     let start = startDate ? parseDateUTC(startDate) : undefined;
     let end = endDate ? parseDateUTC(endDate) : undefined;
@@ -78,7 +79,7 @@ export async function POST(request: NextRequest) {
         name: name || defaultName,
         startDate: start,
         endDate: end,
-        active: active ?? false,
+        active: isFirstPlan ? true : active ?? false,
       },
     });
 


### PR DESCRIPTION
## Summary
- mark a new running plan as active when it's the user's first plan

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da2b13c948324bd0ccde6fef1fb03