### PR TITLE
Switch VO2 max wording to VDOT

### DIFF
--- a/prisma/migrations/20250607215006_init/migration.sql
+++ b/prisma/migrations/20250607215006_init/migration.sql
@@ -27,7 +27,7 @@ CREATE TABLE "Users" (
     "age" INTEGER,
     "gender" "Gender",
     "trainingLevel" "TrainingLevel",
-    "VO2Max" INTEGER,
+    "VDOT" INTEGER,
     "goals" TEXT[],
     "avatarUrl" TEXT,
     "yearsRunning" INTEGER,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,7 +66,7 @@ model User {
   age                          Int?
   gender                       Gender?
   trainingLevel                TrainingLevel?
-  VO2Max                       Int?
+  VDOT                         Int?
   goals                        String[]
   avatarUrl                    String?
   yearsRunning                 Int?

--- a/src/app/api/runs/[id]/route.ts
+++ b/src/app/api/runs/[id]/route.ts
@@ -1,7 +1,7 @@
 // app/api/runs/[id]/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
-import { calculateVO2MaxJackDaniels } from "@utils/running/jackDaniels";
+import { calculateVDOTJackDaniels } from "@utils/running/jackDaniels";
 import { parseDuration } from "@utils/time";
 
 export async function GET(
@@ -46,16 +46,16 @@ export async function PUT(
           ? updatedRun.distance * 1609.34
           : updatedRun.distance * 1000;
       const seconds = parseDuration(updatedRun.duration);
-      const vo2 = Math.round(calculateVO2MaxJackDaniels(meters, seconds));
+      const vdot = Math.round(calculateVDOTJackDaniels(meters, seconds));
       const user = await prisma.user.findUnique({
         where: { id: updatedRun.userId },
-        select: { VO2Max: true },
+        select: { VDOT: true },
       });
-      if (user && (user.VO2Max === null || vo2 > user.VO2Max)) {
-        await prisma.user.update({ where: { id: updatedRun.userId }, data: { VO2Max: vo2 } });
+      if (user && (user.VDOT === null || vdot > user.VDOT)) {
+        await prisma.user.update({ where: { id: updatedRun.userId }, data: { VDOT: vdot } });
       }
     } catch (err) {
-      console.error("Failed to update VO2Max", err);
+      console.error("Failed to update VDOT", err);
     }
 
     return NextResponse.json(updatedRun, { status: 200 });

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/runs/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
-import { calculateVO2MaxJackDaniels } from "@utils/running/jackDaniels";
+import { calculateVDOTJackDaniels } from "@utils/running/jackDaniels";
 import { parseDuration } from "@utils/time";
 
 export async function GET() {
@@ -81,21 +81,21 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Estimate VO2 max from this run and update user only if it's higher
+    // Estimate VDOT from this run and update user only if it's higher
     try {
       const meters =
         distanceUnit === "miles" ? Number(distance) * 1609.34 : Number(distance) * 1000;
       const seconds = parseDuration(duration);
-      const vo2 = Math.round(calculateVO2MaxJackDaniels(meters, seconds));
+      const vdot = Math.round(calculateVDOTJackDaniels(meters, seconds));
       const user = await prisma.user.findUnique({
         where: { id: userId },
-        select: { VO2Max: true },
+        select: { VDOT: true },
       });
-      if (user && (user.VO2Max === null || vo2 > user.VO2Max)) {
-        await prisma.user.update({ where: { id: userId }, data: { VO2Max: vo2 } });
+      if (user && (user.VDOT === null || vdot > user.VDOT)) {
+        await prisma.user.update({ where: { id: userId }, data: { VDOT: vdot } });
       }
     } catch (err) {
-      console.error("Failed to update VO2Max", err);
+      console.error("Failed to update VDOT", err);
     }
 
     return NextResponse.json(newRun, { status: 201 });

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
 
     // Create the new user
     const newUser = await prisma.user.create({
-      data: { ...body, VO2Max: body.VO2Max ?? 30 },
+      data: { ...body, VDOT: body.VDOT ?? 30 },
     });
     return NextResponse.json(newUser, { status: 201 });
   } catch (error: unknown) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,7 +115,7 @@ export default function Landing() {
                 <Target className="w-6 h-6 text-white" />
               </div>
               <h3 className="text-xl font-semibold mb-4">
-                VO₂ Max & Race Prediction
+                VDOT & Race Prediction
               </h3>
               <p className="text-muted-foreground">
                 Know exactly what you&apos;re capable of. Our AI predicts your

--- a/src/components/profile/BasicInfoSection.tsx
+++ b/src/components/profile/BasicInfoSection.tsx
@@ -86,10 +86,10 @@ export default function BasicInfoSection({
             onChange={handleFieldChange}
           />
           <TextField
-            label="VO₂ Max"
-            name="VO2Max"
+            label="VDOT"
+            name="VDOT"
             type="number"
-            value={formData.VO2Max ?? ""}
+            value={formData.VDOT ?? ""}
             editing={isEditing}
             onChange={handleFieldChange}
           />
@@ -132,8 +132,8 @@ export default function BasicInfoSection({
             </dd>
           </div>
           <div>
-            <dt className={styles.label}>VO₂ Max</dt>
-            <dd className={styles.value}>{formData.VO2Max ?? "N/A"}</dd>
+            <dt className={styles.label}>VDOT</dt>
+            <dd className={styles.value}>{formData.VDOT ?? "N/A"}</dd>
           </div>
         </dl>
       )}

--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -38,7 +38,7 @@ const [weeks, setWeeks] = useState<number>(DISTANCE_INFO[DEFAULT_RACE].weeks);
 const [targetDistance, setTargetDistance] = useState<number>(
   DISTANCE_INFO[DEFAULT_RACE].miles
 );
-  const [vo2max, setVo2max] = useState<number>(30);
+  const [vdot, setVdot] = useState<number>(30);
   const [useTotalTime, setUseTotalTime] = useState<boolean>(false);
   const [targetPace, setTargetPace] = useState<string>("10:00");
   const [targetTotalTime, setTargetTotalTime] = useState<string>("3:45:00");
@@ -74,12 +74,12 @@ const [targetDistance, setTargetDistance] = useState<number>(
   useEffect(() => {
     if (user) {
       if (user.trainingLevel) setTrainingLevel(user.trainingLevel);
-      setVo2max(user.VO2Max ?? 30);
+      setVdot(user.VDOT ?? 30);
       if (user.defaultDistanceUnit) setDistanceUnit(user.defaultDistanceUnit);
       // if (user.defaultShoeId) setDefaultShoeId(user.defaultShoeId);
       // Optionally, set other user-specific defaults
     } else {
-      setVo2max(30);
+      setVdot(30);
     }
   }, [user]);
 
@@ -97,7 +97,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
       weeks,
       distanceUnit,
       trainingLevel,
-      vo2max,
+      vdot,
       startingWeeklyMileage: targetDistance,
       targetPace: useTotalTime ? undefined : targetPace,
       targetTotalTime: useTotalTime ? targetTotalTime : undefined,

--- a/src/lib/schemas/userSchema.ts
+++ b/src/lib/schemas/userSchema.ts
@@ -30,13 +30,13 @@ const userSchema = Yup.object().shape({
     .oneOf(trainingLevelValues, "Invalid training level")
     .nullable()
     .default(TrainingLevel.Beginner),
-  VO2Max: Yup.number()
+  VDOT: Yup.number()
     .transform((value, originalValue) =>
       originalValue === "" || originalValue === null
         ? undefined
         : Number(originalValue)
     )
-    .min(10, "VO2Max must be at least 10")
+    .min(10, "VDOT must be at least 10")
     .nullable()
     .default(undefined),
   goals: Yup.array().of(Yup.string()),

--- a/src/lib/utils/__tests__/calculateVDOTJackDaniels.test.ts
+++ b/src/lib/utils/__tests__/calculateVDOTJackDaniels.test.ts
@@ -1,18 +1,18 @@
-import { calculateVO2MaxJackDaniels } from "../running/jackDaniels";
+import { calculateVDOTJackDaniels } from "../running/jackDaniels";
 
-describe("VO2 Max Calculator", () => {
-  it("calculates VO2 max for a 5K race in 20 minutes", () => {
+describe("VDOT Calculator", () => {
+  it("calculates VDOT for a 5K race in 20 minutes", () => {
     const distanceMeters = 5000; // 5 kilometers
     const timeSeconds = 1200; // 20 minutes in seconds
-    const result = calculateVO2MaxJackDaniels(distanceMeters, timeSeconds);
+    const result = calculateVDOTJackDaniels(distanceMeters, timeSeconds);
 
     expect(result).toBeCloseTo(49.8, 1); 
   });
 
-  it("calculates VO2 max for a 10K race in 50 minutes", () => {
+  it("calculates VDOT for a 10K race in 50 minutes", () => {
     const distanceMeters = 10000; // 10 kilometers
     const timeSeconds = 3000; // 50 minutes in seconds
-    const result = calculateVO2MaxJackDaniels(distanceMeters, timeSeconds);
+    const result = calculateVDOTJackDaniels(distanceMeters, timeSeconds);
 
     expect(result).toBeCloseTo(40.01, 1); 
   });
@@ -20,7 +20,7 @@ describe("VO2 Max Calculator", () => {
   it("handles extreme cases of very long races (marathon in 4 hours)", () => {
     const distanceMeters = 42195; // Marathon distance
     const timeSeconds = 14400; // 4 hours in seconds
-    const result = calculateVO2MaxJackDaniels(distanceMeters, timeSeconds);
+    const result = calculateVDOTJackDaniels(distanceMeters, timeSeconds);
 
     expect(result).toBeCloseTo(37.9, 1);
   });

--- a/src/lib/utils/running/jackDaniels.ts
+++ b/src/lib/utils/running/jackDaniels.ts
@@ -1,6 +1,6 @@
 import { formatPace } from "@utils/running/paces";
 
-export const calculateVO2MaxJackDaniels = (
+export const calculateVDOTJackDaniels = (
   distanceMeters: number,
   timeSeconds: number
 ): number => {
@@ -16,9 +16,9 @@ export const calculateVO2MaxJackDaniels = (
 
   const vo2 = -4.6 + 0.182258 * velocity + 0.000104 * Math.pow(velocity, 2);
 
-  const vo2Max = vo2 / vo2MaxPercentage;
+  const vdot = vo2 / vo2MaxPercentage;
 
-  return vo2Max;
+  return vdot;
 };
 
 type PaceZone = "E" | "M" | "T" | "I" | "R";
@@ -36,17 +36,17 @@ const ZONE_FACTORS: Record<PaceZone, number> = {
  * Invert Daniels’ VO₂→pace model for a given zone.
  *
  * @param distanceMeters  Race distance in meters
- * @param targetVO2Max    Runner’s VDOT/VO₂-max
+ * @param targetVDOT      Runner’s VDOT
  * @param zone            One of "E","M","T","I","R"
  * @returns               Pace string "mm:ss" per mile
  */
-export function calculatePaceForVO2Max(
+export function calculatePaceForVDOT(
   distanceMeters: number,
-  targetVO2Max: number,
+  targetVDOT: number,
   zone: PaceZone
 ): string {
   // adjust VO₂ for zone intensity
-  const zonalVO2 = targetVO2Max * ZONE_FACTORS[zone];
+  const zonalVO2 = targetVDOT * ZONE_FACTORS[zone];
 
   // binary search bounds on race time (in seconds)
   let low = distanceMeters / 10; // super-fast
@@ -55,7 +55,7 @@ export function calculatePaceForVO2Max(
 
   for (let i = 0; i < 50; i++) {
     mid = (low + high) / 2;
-    const vo2 = calculateVO2MaxJackDaniels(distanceMeters, mid);
+    const vo2 = calculateVDOTJackDaniels(distanceMeters, mid);
     if (Math.abs(vo2 - zonalVO2) < 0.1) break;
     if (vo2 < zonalVO2) {
       // mid is too slow (VO₂ too low), speed up

--- a/src/lib/utils/running/plans/distancePlans.ts
+++ b/src/lib/utils/running/plans/distancePlans.ts
@@ -6,7 +6,7 @@ export interface DistancePlanOptions {
   weeks?: number;
   distanceUnit: Unit;
   trainingLevel: TrainingLevel;
-  vo2max: number;
+  vdot: number;
   startingWeeklyMileage: number;
   targetPace?: string;
   targetTotalTime?: string;
@@ -21,7 +21,7 @@ export function generate5kPlan(options: DistancePlanOptions): RunningPlanData {
     weeks = 8,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -32,7 +32,7 @@ export function generate5kPlan(options: DistancePlanOptions): RunningPlanData {
     dist,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -44,7 +44,7 @@ export function generate10kPlan(options: DistancePlanOptions): RunningPlanData {
     weeks = 10,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -55,7 +55,7 @@ export function generate10kPlan(options: DistancePlanOptions): RunningPlanData {
     dist,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -67,7 +67,7 @@ export function generateHalfMarathonPlan(options: DistancePlanOptions): RunningP
     weeks = 12,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -78,7 +78,7 @@ export function generateHalfMarathonPlan(options: DistancePlanOptions): RunningP
     dist,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -90,7 +90,7 @@ export function generateClassicMarathonPlan(options: DistancePlanOptions): Runni
     weeks = 16,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,
@@ -101,7 +101,7 @@ export function generateClassicMarathonPlan(options: DistancePlanOptions): Runni
     dist,
     distanceUnit,
     trainingLevel,
-    vo2max,
+    vdot,
     startingWeeklyMileage,
     targetPace,
     targetTotalTime,

--- a/src/lib/utils/running/plans/longDistancePlan.ts
+++ b/src/lib/utils/running/plans/longDistancePlan.ts
@@ -1,4 +1,4 @@
-import { calculatePaceForVO2Max } from "../jackDaniels";
+import { calculatePaceForVDOT } from "../jackDaniels";
 import { WeekPlan, RunningPlanData, PlannedRun } from "@maratypes/runningPlan";
 import { formatPace } from "@utils/running/paces";
 
@@ -140,7 +140,7 @@ export function generateLongDistancePlan(
   targetDistance: number,
   distanceUnit: Unit,
   trainingLevel: TrainingLevel,
-  vo2max: number,
+  vdot: number,
   _startingWeeklyMileage: number,
   targetPace?: string,
   targetTotalTime?: string
@@ -177,10 +177,10 @@ export function generateLongDistancePlan(
 
   // -- pace zones
   const zones: PaceZones = {
-    easy: calculatePaceForVO2Max(raceMeters, vo2max, "E"),
-    marathon: calculatePaceForVO2Max(raceMeters, vo2max, "M"),
-    tempo: calculatePaceForVO2Max(raceMeters, vo2max, "T"),
-    interval: calculatePaceForVO2Max(raceMeters, vo2max, "I"),
+    easy: calculatePaceForVDOT(raceMeters, vdot, "E"),
+    marathon: calculatePaceForVDOT(raceMeters, vdot, "M"),
+    tempo: calculatePaceForVDOT(raceMeters, vdot, "T"),
+    interval: calculatePaceForVDOT(raceMeters, vdot, "I"),
   };
   if (goalPaceSec !== undefined) zones.marathon = formatPace(goalPaceSec);
 

--- a/src/lib/utils/running/plans/shortDistancePlan.ts
+++ b/src/lib/utils/running/plans/shortDistancePlan.ts
@@ -1,4 +1,4 @@
-import { calculatePaceForVO2Max } from "../jackDaniels";
+import { calculatePaceForVDOT } from "../jackDaniels";
 import { WeekPlan, RunningPlanData, PlannedRun } from "@maratypes/runningPlan";
 
 export const Units = ["miles", "kilometers"] as const;
@@ -49,7 +49,7 @@ export function generateShortDistancePlan(
   raceDistance: number,
   distanceUnit: Unit,
   trainingLevel: TrainingLevel,
-  vo2max: number,
+  vdot: number,
 ): RunningPlanData {
   if (weeks < MIN_WEEKS) throw new Error(`Plan must be ≥ ${MIN_WEEKS} weeks.`);
   if (raceDistance <= 0) throw new Error("Distance must be > 0");
@@ -64,10 +64,10 @@ export function generateShortDistancePlan(
   const raceKm = toKm(raceDistance);
   const raceMeters = raceKm * 1000;
 
-  const paceE = calculatePaceForVO2Max(raceMeters, vo2max, "E");
-  const paceM = calculatePaceForVO2Max(raceMeters, vo2max, "M");
-  const paceT = calculatePaceForVO2Max(raceMeters, vo2max, "T");
-  const paceI = calculatePaceForVO2Max(raceMeters, vo2max, "I");
+  const paceE = calculatePaceForVDOT(raceMeters, vdot, "E");
+  const paceM = calculatePaceForVDOT(raceMeters, vdot, "M");
+  const paceT = calculatePaceForVDOT(raceMeters, vdot, "T");
+  const paceI = calculatePaceForVDOT(raceMeters, vdot, "I");
 
   const buildWeeks = weeks - TAPER_WEEKS;
   const phases = [

--- a/src/maratypes/user.ts
+++ b/src/maratypes/user.ts
@@ -27,7 +27,7 @@ export interface User {
   age?: number;
   gender?: Gender;
   trainingLevel?: TrainingLevel;
-  VO2Max?: number;
+  VDOT?: number;
   goals?: string[];
   avatarUrl?: string;
   yearsRunning?: number;


### PR DESCRIPTION
## Summary
- rename User VO2Max field to VDOT across schema and code
- update calculations and training plan utilities to use VDOT
- adjust profile and plan generator components
- update copy to mention VDOT
- rename and update test for VDOT calculator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da4baf3fc8324a9ff02464ef6d98d