### PR TITLE
Add muted color to theme and tailwind config

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,6 +1,7 @@
 :root {
   --background: #f9fafb;
   --foreground: #1f2937;
+  --muted: #f3f4f6; /* Tailwind gray-100 */
   --muted-foreground: #6b7280; /* Tailwind gray-500 */
   --primary-rgb: 99, 102, 241;    /* #6366f1 indigo */
   --secondary-rgb: 79, 70, 229;   /* #4f46e5 */
@@ -19,6 +20,7 @@
   :root {
     --background: #0f172a;
     --foreground: #f8fafc;
+    --muted: #1f2937; /* Tailwind gray-800 */
     --muted-foreground: #9ca3af; /* Tailwind gray-400 */
     --primary-rgb: 165, 180, 252;  /* #a5b4fc */
     --secondary-rgb: 129, 140, 248;/* #818cf8 */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,7 @@ export default {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+        muted: "var(--muted)",
         "muted-foreground": "var(--muted-foreground)",
         primary: "rgb(var(--primary-rgb) / <alpha-value>)",
         secondary: "rgb(var(--secondary-rgb) / <alpha-value>)",


### PR DESCRIPTION
## Summary
- add `--muted` color variable in light and dark themes
- expose `muted` in Tailwind theme configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da85186608324b7b4dbd368c694d0