### PR TITLE
Enhance short distance plan pacing

### DIFF
--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -98,7 +98,6 @@ const [targetDistance, setTargetDistance] = useState<number>(
       distanceUnit,
       trainingLevel,
       vdot,
-      startingWeeklyMileage: targetDistance,
       targetPace: useTotalTime ? undefined : targetPace,
       targetTotalTime: useTotalTime ? targetTotalTime : undefined,
     };

--- a/src/lib/utils/__tests__/shortDistancePlan.test.ts
+++ b/src/lib/utils/__tests__/shortDistancePlan.test.ts
@@ -1,0 +1,28 @@
+import { generateShortDistancePlan, TrainingLevel } from "../running/plans/shortDistancePlan";
+
+describe("generateShortDistancePlan", () => {
+  it("sets final run as race", () => {
+    const weeks = 6;
+    const plan = generateShortDistancePlan(weeks, 6.2, "miles", TrainingLevel.Beginner, 40);
+    const lastWeek = plan.schedule[weeks - 1];
+    const lastRun = lastWeek.runs[lastWeek.runs.length - 1];
+    expect(lastRun.type).toBe("race");
+  });
+
+  it("splits easy mileage into multiple runs", () => {
+    const plan = generateShortDistancePlan(8, 6.2, "miles", TrainingLevel.Beginner, 40);
+    plan.schedule.forEach((week) => {
+      const easyRuns = week.runs.filter((r) => r.type === "easy");
+      expect(easyRuns.length).toBeGreaterThan(1);
+    });
+  });
+
+  it("throws for week counts outside 4-16", () => {
+    expect(() =>
+      generateShortDistancePlan(3, 6.2, "miles", TrainingLevel.Beginner, 40)
+    ).toThrow();
+    expect(() =>
+      generateShortDistancePlan(17, 6.2, "miles", TrainingLevel.Beginner, 40)
+    ).toThrow();
+  });
+});

--- a/src/lib/utils/__tests__/weeklyMileageSum.test.ts
+++ b/src/lib/utils/__tests__/weeklyMileageSum.test.ts
@@ -12,7 +12,7 @@ describe("weeklyMileage totals", () => {
   });
 
   it("short plan weekly mileage equals sum of runs", () => {
-    const plan = generateShortDistancePlan(8, 6.2, "miles", ShortLevel.Beginner, 40, 6.2);
+    const plan = generateShortDistancePlan(8, 6.2, "miles", ShortLevel.Beginner, 40);
     plan.schedule.forEach((week) => {
       const sum = week.runs.reduce((tot, r) => tot + r.mileage, 0);
       expect(Number(sum.toFixed(1))).toBeCloseTo(week.weeklyMileage, 1);

--- a/src/lib/utils/running/jackDaniels.ts
+++ b/src/lib/utils/running/jackDaniels.ts
@@ -71,3 +71,32 @@ export function calculatePaceForVDOT(
   const paceSec = mid / (distanceMeters / metersPerMile);
   return formatPace(paceSec);
 }
+
+/**
+ * Predicts race-pace from a VDOT value for the given distance.
+ * This is identical to `calculatePaceForVDOT` but without any
+ * zone adjustment so the result represents goal pace.
+ */
+export function calculateGoalPaceForVDOT(
+  distanceMeters: number,
+  targetVDOT: number
+): string {
+  let low = distanceMeters / 10;
+  let high = distanceMeters;
+  let mid = 0;
+
+  for (let i = 0; i < 50; i++) {
+    mid = (low + high) / 2;
+    const vo2 = calculateVDOTJackDaniels(distanceMeters, mid);
+    if (Math.abs(vo2 - targetVDOT) < 0.1) break;
+    if (vo2 < targetVDOT) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  const metersPerMile = 1609.34;
+  const paceSec = mid / (distanceMeters / metersPerMile);
+  return formatPace(paceSec);
+}

--- a/src/lib/utils/running/plans/distancePlans.ts
+++ b/src/lib/utils/running/plans/distancePlans.ts
@@ -7,7 +7,7 @@ export interface DistancePlanOptions {
   distanceUnit: Unit;
   trainingLevel: TrainingLevel;
   vdot: number;
-  startingWeeklyMileage: number;
+  startingWeeklyMileage?: number;
   targetPace?: string;
   targetTotalTime?: string;
 }
@@ -17,15 +17,7 @@ function toDistance(unit: Unit, milesVal: number, kmVal: number): number {
 }
 
 export function generate5kPlan(options: DistancePlanOptions): RunningPlanData {
-  const {
-    weeks = 8,
-    distanceUnit,
-    trainingLevel,
-    vdot,
-    startingWeeklyMileage,
-    targetPace,
-    targetTotalTime,
-  } = options;
+  const { weeks = 8, distanceUnit, trainingLevel, vdot } = options;
   const dist = toDistance(distanceUnit, 3.1, 5);
   return generateShortDistancePlan(
     weeks,
@@ -33,22 +25,11 @@ export function generate5kPlan(options: DistancePlanOptions): RunningPlanData {
     distanceUnit,
     trainingLevel,
     vdot,
-    startingWeeklyMileage,
-    targetPace,
-    targetTotalTime,
   );
 }
 
 export function generate10kPlan(options: DistancePlanOptions): RunningPlanData {
-  const {
-    weeks = 10,
-    distanceUnit,
-    trainingLevel,
-    vdot,
-    startingWeeklyMileage,
-    targetPace,
-    targetTotalTime,
-  } = options;
+  const { weeks = 10, distanceUnit, trainingLevel, vdot } = options;
   const dist = toDistance(distanceUnit, 6.2, 10);
   return generateShortDistancePlan(
     weeks,
@@ -56,9 +37,6 @@ export function generate10kPlan(options: DistancePlanOptions): RunningPlanData {
     distanceUnit,
     trainingLevel,
     vdot,
-    startingWeeklyMileage,
-    targetPace,
-    targetTotalTime,
   );
 }
 


### PR DESCRIPTION
## Summary
- refine short distance plan pace derivation and tapering
- validate week limits and distribute easy runs across multiple days
- update generators to use new short plan API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da7063cd08324957c9683f06bdafc