### PR TITLE
Add distance-based naming for training plans

### DIFF
--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -14,8 +14,12 @@ import {
 import { RunningPlanData } from "@maratypes/runningPlan";
 import { createRunningPlan, listRunningPlans } from "@lib/api/plan";
 import { assignDatesToPlan } from "@utils/running/planDates";
+import {
+  defaultPlanName,
+  getDistanceLabel,
+  RaceType,
+} from "@utils/running/planName";
 
-type RaceType = "5k" | "10k" | "half" | "full";
 
 const DISTANCE_INFO: Record<RaceType, { miles: number; km: number; weeks: number }> = {
   "5k": { miles: 3.1, km: 5, weeks: 8 },
@@ -45,7 +49,9 @@ const [targetDistance, setTargetDistance] = useState<number>(
   const [planData, setPlanData] = useState<RunningPlanData | null>(null);
   const [showJson, setShowJson] = useState<boolean>(false);
   const [editPlan, setEditPlan] = useState<boolean>(false);
-  const [planName, setPlanName] = useState<string>("Training Plan 1");
+  const [planName, setPlanName] = useState<string>(
+    defaultPlanName(DEFAULT_RACE, 1)
+  );
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
 
@@ -58,14 +64,16 @@ const [targetDistance, setTargetDistance] = useState<number>(
       if (!user?.id) return;
       try {
         const all = await listRunningPlans();
-        const count = all.filter((p: { userId: string }) => p.userId === user.id).length;
-        setPlanName(`Training Plan ${count + 1}`);
+        const userPlans = all.filter((p: { userId: string; name?: string }) => p.userId === user.id);
+        const label = getDistanceLabel(raceType);
+        const count = userPlans.filter(p => p.name?.startsWith(label)).length;
+        setPlanName(defaultPlanName(raceType, count + 1));
       } catch (err) {
         console.error(err);
       }
     };
     fetchName();
-  }, [user?.id]);
+  }, [user?.id, raceType]);
   // const [defaultShoeId, setDefaultShoeId] = useState<string | undefined>(
   //   undefined
   // );

--- a/src/lib/utils/__tests__/planName.test.ts
+++ b/src/lib/utils/__tests__/planName.test.ts
@@ -1,0 +1,18 @@
+import { defaultPlanName, getDistanceLabel, RaceType } from '../running/planName';
+
+describe('plan name utils', () => {
+  const cases: Array<[RaceType, number, string]> = [
+    ['5k', 1, '5K Training Plan 1'],
+    ['10k', 2, '10K Training Plan 2'],
+    ['half', 3, 'Half Marathon Training Plan 3'],
+    ['full', 4, 'Marathon Training Plan 4'],
+  ];
+
+  it.each(cases)('defaultPlanName %s %d', (race, count, expected) => {
+    expect(defaultPlanName(race, count)).toBe(expected);
+  });
+
+  it('getDistanceLabel returns correct label', () => {
+    expect(getDistanceLabel('full')).toBe('Marathon');
+  });
+});

--- a/src/lib/utils/running/planName.ts
+++ b/src/lib/utils/running/planName.ts
@@ -1,0 +1,17 @@
+export type RaceType = "5k" | "10k" | "half" | "full";
+
+const LABELS: Record<RaceType, string> = {
+  "5k": "5K",
+  "10k": "10K",
+  half: "Half Marathon",
+  full: "Marathon",
+};
+
+export function getDistanceLabel(race: RaceType): string {
+  return LABELS[race] || "";
+}
+
+export function defaultPlanName(race: RaceType, count: number): string {
+  const label = getDistanceLabel(race);
+  return `${label} Training Plan ${count}`;
+}


### PR DESCRIPTION
## Summary
- add `planName` utility with helpers for race labels
- update `PlanGenerator` to compute default name from distance
- support optional race type in running plan API route
- test plan name helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da925f5f88324b7e5fff174ad94d9