### PR TITLE
Handle run unselect

### DIFF
--- a/src/components/runs/DashboardStats.tsx
+++ b/src/components/runs/DashboardStats.tsx
@@ -41,6 +41,9 @@ export default function DashboardStats() {
       }
     }
     fetchRuns();
+    const handle = () => fetchRuns();
+    window.addEventListener("runsUpdated", handle);
+    return () => window.removeEventListener("runsUpdated", handle);
   }, [session?.user, profile?.defaultDistanceUnit]);
 
   return (

--- a/src/components/runs/RecentRuns.tsx
+++ b/src/components/runs/RecentRuns.tsx
@@ -35,6 +35,9 @@ export default function RecentRuns() {
     };
 
     fetchRuns();
+    const handle = () => fetchRuns();
+    window.addEventListener("runsUpdated", handle);
+    return () => window.removeEventListener("runsUpdated", handle);
   }, [session?.user?.id]);
 
   if (loading)

--- a/src/components/runs/RunsList.tsx
+++ b/src/components/runs/RunsList.tsx
@@ -35,6 +35,9 @@ export default function RunsList() {
     };
 
     fetchRuns();
+    const handle = () => fetchRuns();
+    window.addEventListener("runsUpdated", handle);
+    return () => window.removeEventListener("runsUpdated", handle);
   }, [session?.user?.id]);
 
   if (loading)


### PR DESCRIPTION
## Summary
- allow WeeklyRuns to delete matching Run when unchecked
- trigger `runsUpdated` events on create/delete
- refresh run listings and dashboard totals when runs change

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de5564b888324a3010f9eeb556294