### PR TITLE
Show bulk day setter during plan generation

### DIFF
--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -338,6 +338,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
             planData={planData}
             planName={planName}
             editable={editPlan}
+            showBulkDaySetter
             onPlanChange={setPlanData}
           />
           <div className="mt-4">

--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -8,6 +8,10 @@ interface RunningPlanDisplayProps {
   planData: RunningPlanData;
   planName?: string;
   editable?: boolean;
+  /**
+   * Show the bulk day setter even when the plan is not editable.
+   */
+  showBulkDaySetter?: boolean;
   onPlanChange?: (plan: RunningPlanData) => void;
 }
 
@@ -15,6 +19,7 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
   planData,
   planName,
   editable = false,
+  showBulkDaySetter = false,
   onPlanChange,
 }) => {
   const updateRun = (weekIdx: number, runIdx: number, field: string, value: unknown) => {
@@ -33,7 +38,7 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
       <h2 className="text-2xl font-bold text-center mb-4">
         {planName || "Your Running Plan"}
       </h2>
-      {editable && (
+      {(editable || showBulkDaySetter) && (
         <BulkDaySetter
           planData={planData}
           onPlanChange={onPlanChange}


### PR DESCRIPTION
## Summary
- allow `RunningPlanDisplay` to display the bulk day setter when not in edit mode
- always show the bulk day setter in `PlanGenerator`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e1281c6ac83249b3f90b25c983e43