### PR TITLE
Add VDOT edit field on profile

### DIFF
--- a/src/app/signup/profile/page.tsx
+++ b/src/app/signup/profile/page.tsx
@@ -39,7 +39,7 @@ export default function OnboardingProfile() {
     await updateUser(initialUser.id, updated);
     // Refresh session so avatar updates in navbar
     await update({ user: { avatarUrl: updated.avatarUrl ?? null } });
-    router.push("/signup/vdot");
+    router.push("/home");
   };
 
   return (
@@ -56,6 +56,7 @@ export default function OnboardingProfile() {
               onSave={onSave}
               alwaysEdit
               submitLabel="Finish Setup"
+              showVDOTField={false}
             />
           </Card>
         </div>

--- a/src/components/profile/BasicInfoSection.tsx
+++ b/src/components/profile/BasicInfoSection.tsx
@@ -18,12 +18,15 @@ interface Props {
   formData: Partial<User>;
   isEditing: boolean;
   onChange: (field: keyof User, value: string) => void;
+  /** show the VDOT field when editing */
+  showVDOTField?: boolean;
 }
 
 export default function BasicInfoSection({
   formData,
   isEditing,
   onChange,
+  showVDOTField = true,
 }: Props) {
   const handleFieldChange = (name: string, value: string) =>
     onChange(name as keyof User, value);
@@ -85,14 +88,16 @@ export default function BasicInfoSection({
             editing={isEditing}
             onChange={handleFieldChange}
           />
-          {/* <TextField
-            label="VDOT"
-            name="VDOT"
-            type="number"
-            value={formData.VDOT ?? ""}
-            editing={isEditing}
-            onChange={handleFieldChange}
-          /> */}
+          {showVDOTField && (
+            <TextField
+              label="VDOT"
+              name="VDOT"
+              type="number"
+              value={formData.VDOT ?? ""}
+              editing={isEditing}
+              onChange={handleFieldChange}
+            />
+          )}
         </div>
       ) : (
         <dl className={`${styles.list} flex flex-col gap-4`}>

--- a/src/components/profile/UserProfileForm.tsx
+++ b/src/components/profile/UserProfileForm.tsx
@@ -14,13 +14,16 @@ interface Props {
   /** always show fields in edit mode */
   alwaysEdit?: boolean;
   submitLabel?: string;
+  /** show VDOT field when editing */
+  showVDOTField?: boolean;
 }
 
 export default function UserProfileForm({
   initialUser,
   onSave,
-  alwaysEdit = false, 
-  submitLabel = "Save Profile"
+  alwaysEdit = false,
+  submitLabel = "Save Profile",
+  showVDOTField = true,
 }: Props) {
   const {
     formData,
@@ -72,6 +75,7 @@ export default function UserProfileForm({
         formData={formData}
         isEditing={editing}
         onChange={handleChange}
+        showVDOTField={showVDOTField}
       />
       <PhysicalStatsSection
         formData={formData}


### PR DESCRIPTION
## Summary
- allow BasicInfoSection to optionally show VDOT field
- add showVDOTField flag to UserProfileForm
- hide VDOT input during signup and redirect directly to `/home`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f39aede288324a5ef177aa72b2cfb