### PR TITLE
Add run groups feature

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,8 +47,8 @@ enum Device {
   Polar
   Suunto
   Fitbit
-  AppleWatch          @map("Apple Watch")
-  SamsungGalaxyWatch  @map("Samsung Galaxy Watch")
+  AppleWatch         @map("Apple Watch")
+  SamsungGalaxyWatch @map("Samsung Galaxy Watch")
   Coros
   Other
 }
@@ -60,9 +60,9 @@ enum Gender {
 }
 
 model User {
-  id                           String              @id @default(uuid())
+  id                           String               @id @default(uuid())
   name                         String
-  email                        String              @unique
+  email                        String               @unique
   age                          Int?
   gender                       Gender?
   trainingLevel                TrainingLevel?
@@ -77,50 +77,50 @@ model User {
   preferredTrainingDays        DayOfWeek[]
   preferredTrainingEnvironment TrainingEnvironment?
   device                       Device?
-  defaultDistanceUnit          DistanceUnit?       @default(miles)
-  defaultElevationUnit         elevationGainUnit?  @default(feet)
-  createdAt                    DateTime            @default(now())
-  updatedAt                    DateTime            @updatedAt
+  defaultDistanceUnit          DistanceUnit?        @default(miles)
+  defaultElevationUnit         elevationGainUnit?   @default(feet)
+  createdAt                    DateTime             @default(now())
+  updatedAt                    DateTime             @updatedAt
 
-  runs                         Run[]
-  runningPlans                 RunningPlan[]
-  shoes                        Shoe[]    @relation("UserShoes")
+  runs         Run[]
+  runningPlans RunningPlan[]
+  shoes        Shoe[]        @relation("UserShoes")
 
-  profile                      SocialProfile?
+  profile SocialProfile?
 
   // Default shoe relation
-  defaultShoeId                String?   @unique
-  defaultShoe                  Shoe?     @relation("UserDefaultShoe", fields: [defaultShoeId], references: [id])
+  defaultShoeId String? @unique
+  defaultShoe   Shoe?   @relation("UserDefaultShoe", fields: [defaultShoeId], references: [id])
 
   @@map("Users")
 }
 
 model Shoe {
-  id                String   @id @default(uuid())
-  name              String
-  notes             String?
-  createdAt         DateTime    @default(now())
-  updatedAt         DateTime    @updatedAt
+  id        String   @id @default(uuid())
+  name      String
+  notes     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  currentDistance   Float       @default(0) // Usage so far (in distanceUnit)
-  distanceUnit      DistanceUnit
-  maxDistance       Float       // When shoe “expires” (in distanceUnit)
-  retired           Boolean     @default(false)
+  currentDistance Float        @default(0) // Usage so far (in distanceUnit)
+  distanceUnit    DistanceUnit
+  maxDistance     Float // When shoe “expires” (in distanceUnit)
+  retired         Boolean      @default(false)
 
   // Owner
-  userId            String
-  user              User     @relation("UserShoes", fields: [userId], references: [id])
+  userId String
+  user   User   @relation("UserShoes", fields: [userId], references: [id])
 
   // Back-ref for default shoe relation
-  defaultForUser    User?    @relation("UserDefaultShoe")
+  defaultForUser User? @relation("UserDefaultShoe")
 
-  runs              Run[]
+  runs Run[]
 
   @@map("Shoes")
 }
 
 model Run {
-  id                  String              @id @default(uuid())
+  id                  String               @id @default(uuid())
   date                DateTime
   duration            String
   distance            Float
@@ -132,21 +132,21 @@ model Run {
   elevationGain       Float?
   elevationGainUnit   elevationGainUnit?
   notes               String?
-  createdAt           DateTime            @default(now())
-  updatedAt           DateTime            @updatedAt
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
 
-  userId              String
-  user                User   @relation(fields: [userId], references: [id])
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
 
   // Shoe used in this run (optional for legacy runs)
-  shoeId              String?
-  shoe                Shoe?  @relation(fields: [shoeId], references: [id])
+  shoeId String?
+  shoe   Shoe?   @relation(fields: [shoeId], references: [id])
 
   @@map("Runs")
 }
 
 model RunningPlan {
-  id        String   @id @default(uuid())
+  id        String    @id @default(uuid())
   userId    String
   name      String
   weeks     Int
@@ -154,79 +154,81 @@ model RunningPlan {
   startDate DateTime?
   endDate   DateTime?
   active    Boolean   @default(false)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
-  user      User     @relation(fields: [userId], references: [id])
+  user User @relation(fields: [userId], references: [id])
 
   @@map("RunningPlans")
 }
 
 model SocialProfile {
-  id          String   @id @default(uuid())
-  userId      String   @unique
-  username    String   @unique
-  bio         String?
+  id           String   @id @default(uuid())
+  userId       String   @unique
+  username     String   @unique
+  bio          String?
   profilePhoto String?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  user        User     @relation(fields: [userId], references: [id])
-  posts       RunPost[]
-  following   Follow[] @relation("following")
-  followers   Follow[] @relation("followers")
-  comments    Comment[]
-  likes       Like[]
+  user           User             @relation(fields: [userId], references: [id])
+  posts          RunPost[]
+  following      Follow[]         @relation("following")
+  followers      Follow[]         @relation("followers")
+  comments       Comment[]
+  likes          Like[]
+  RunGroup       RunGroup[]
+  RunGroupMember RunGroupMember[]
 }
 
 model RunPost {
-  id            String     @id @default(uuid())
+  id              String   @id @default(uuid())
   socialProfileId String
-  groupId       String?
-  distance      Float
-  time          String
-  caption       String?
-  photoUrl      String?
-  createdAt     DateTime   @default(now())
-  updatedAt     DateTime   @updatedAt
+  groupId         String?
+  distance        Float
+  time            String
+  caption         String?
+  photoUrl        String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
-  socialProfile   SocialProfile @relation(fields: [socialProfileId], references: [id])
-  group          RunGroup?      @relation(fields: [groupId], references: [id])
+  socialProfile SocialProfile @relation(fields: [socialProfileId], references: [id])
+  group         RunGroup?     @relation(fields: [groupId], references: [id])
   comments      Comment[]
   likes         Like[]
 }
 
 model Follow {
-  id           String   @id @default(uuid())
-  followerId   String
-  followingId  String
-  createdAt    DateTime @default(now())
+  id          String   @id @default(uuid())
+  followerId  String
+  followingId String
+  createdAt   DateTime @default(now())
 
-  follower     SocialProfile @relation("following", fields: [followerId], references: [id])
-  following    SocialProfile @relation("followers", fields: [followingId], references: [id])
+  follower  SocialProfile @relation("following", fields: [followerId], references: [id])
+  following SocialProfile @relation("followers", fields: [followingId], references: [id])
 
   @@unique([followerId, followingId])
 }
 
 model Comment {
-  id            String   @id @default(uuid())
-  postId        String
+  id              String   @id @default(uuid())
+  postId          String
   socialProfileId String
-  text          String
-  createdAt     DateTime @default(now())
+  text            String
+  createdAt       DateTime @default(now())
 
-  post          RunPost     @relation(fields: [postId], references: [id])
-  socialProfile   SocialProfile @relation(fields: [socialProfileId], references: [id])
+  post          RunPost       @relation(fields: [postId], references: [id])
+  socialProfile SocialProfile @relation(fields: [socialProfileId], references: [id])
 }
 
 model Like {
-  id            String   @id @default(uuid())
-  postId        String
+  id              String   @id @default(uuid())
+  postId          String
   socialProfileId String
-  createdAt     DateTime @default(now())
+  createdAt       DateTime @default(now())
 
-  post          RunPost     @relation(fields: [postId], references: [id])
-  socialProfile   SocialProfile @relation(fields: [socialProfileId], references: [id])
+  post          RunPost       @relation(fields: [postId], references: [id])
+  socialProfile SocialProfile @relation(fields: [socialProfileId], references: [id])
 
   @@unique([postId, socialProfileId])
 }
@@ -240,15 +242,15 @@ model RunGroup {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  owner   SocialProfile @relation(fields: [ownerId], references: [id])
+  owner   SocialProfile    @relation(fields: [ownerId], references: [id])
   members RunGroupMember[]
   posts   RunPost[]
 }
 
 model RunGroupMember {
-  groupId        String
+  groupId         String
   socialProfileId String
-  joinedAt       DateTime @default(now())
+  joinedAt        DateTime @default(now())
 
   group         RunGroup      @relation(fields: [groupId], references: [id])
   socialProfile SocialProfile @relation(fields: [socialProfileId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,6 +182,7 @@ model SocialProfile {
 model RunPost {
   id            String     @id @default(uuid())
   socialProfileId String
+  groupId       String?
   distance      Float
   time          String
   caption       String?
@@ -190,6 +191,7 @@ model RunPost {
   updatedAt     DateTime   @updatedAt
 
   socialProfile   SocialProfile @relation(fields: [socialProfileId], references: [id])
+  group          RunGroup?      @relation(fields: [groupId], references: [id])
   comments      Comment[]
   likes         Like[]
 }
@@ -227,4 +229,29 @@ model Like {
   socialProfile   SocialProfile @relation(fields: [socialProfileId], references: [id])
 
   @@unique([postId, socialProfileId])
+}
+
+model RunGroup {
+  id          String   @id @default(uuid())
+  name        String
+  description String?
+  private     Boolean  @default(false)
+  ownerId     String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  owner   SocialProfile @relation(fields: [ownerId], references: [id])
+  members RunGroupMember[]
+  posts   RunPost[]
+}
+
+model RunGroupMember {
+  groupId        String
+  socialProfileId String
+  joinedAt       DateTime @default(now())
+
+  group         RunGroup      @relation(fields: [groupId], references: [id])
+  socialProfile SocialProfile @relation(fields: [socialProfileId], references: [id])
+
+  @@id([groupId, socialProfileId])
 }

--- a/src/app/api/social/feed/route.ts
+++ b/src/app/api/social/feed/route.ts
@@ -18,7 +18,10 @@ export async function GET(req: NextRequest) {
     const ids = followed.map((f) => f.followingId);
     if (viewerProfile) ids.push(viewerProfile.id);
     const posts = await prisma.runPost.findMany({
-      where: { socialProfileId: { in: ids } },
+      where: {
+        socialProfileId: { in: ids },
+        groupId: null,
+      },
       include: {
         socialProfile: {
           include: { user: { select: { avatarUrl: true } } },

--- a/src/app/api/social/feed/route.ts
+++ b/src/app/api/social/feed/route.ts
@@ -7,11 +7,16 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "userId required" }, { status: 400 });
   }
   try {
+    const viewerProfile = await prisma.socialProfile.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
     const followed = await prisma.follow.findMany({
       where: { follower: { userId } },
       select: { followingId: true },
     });
     const ids = followed.map((f) => f.followingId);
+    if (viewerProfile) ids.push(viewerProfile.id);
     const posts = await prisma.runPost.findMany({
       where: { socialProfileId: { in: ids } },
       include: {

--- a/src/app/api/social/groups/[id]/join/route.ts
+++ b/src/app/api/social/groups/[id]/join/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function POST(req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
+  const { profileId } = await req.json();
+  if (!profileId) {
+    return NextResponse.json({ error: "profileId required" }, { status: 400 });
+  }
+  try {
+    await prisma.runGroupMember.upsert({
+      where: { groupId_socialProfileId: { groupId: id, socialProfileId: profileId } },
+      update: {},
+      create: { groupId: id, socialProfileId: profileId },
+    });
+    return NextResponse.json({}, { status: 201 });
+  } catch (err) {
+    console.error("Error joining group", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/groups/[id]/posts/route.ts
+++ b/src/app/api/social/groups/[id]/posts/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
+  const profileId = req.nextUrl.searchParams.get("profileId");
+  try {
+    const posts = await prisma.runPost.findMany({
+      where: { groupId: id },
+      include: {
+        socialProfile: { include: { user: { select: { avatarUrl: true } } } },
+        _count: { select: { likes: true, comments: true } },
+        likes: profileId
+          ? { where: { socialProfileId: profileId }, select: { id: true } }
+          : undefined,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    const mapped = posts.map((p) => ({
+      id: p.id,
+      socialProfileId: p.socialProfileId,
+      groupId: p.groupId,
+      distance: p.distance,
+      time: p.time,
+      caption: p.caption,
+      photoUrl: p.photoUrl,
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+      socialProfile: p.socialProfile,
+      likeCount: p._count.likes,
+      commentCount: p._count.comments,
+      liked: profileId ? p.likes.length > 0 : false,
+    }));
+    return NextResponse.json(mapped);
+  } catch (err) {
+    console.error("Error listing group posts", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
+  const data = await req.json();
+  try {
+    const post = await prisma.runPost.create({
+      data: { ...data, groupId: id },
+    });
+    return NextResponse.json(post, { status: 201 });
+  } catch (err) {
+    console.error("Error creating group post", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/groups/[id]/route.ts
+++ b/src/app/api/social/groups/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
+  const { id } = ctx.params;
+  const profileId = req.nextUrl.searchParams.get("profileId");
+  try {
+    const group = await prisma.runGroup.findUnique({
+      where: { id },
+      include: { owner: true, _count: { select: { members: true } } },
+    });
+    if (!group) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    let isMember = false;
+    if (profileId) {
+      const m = await prisma.runGroupMember.findUnique({
+        where: { groupId_socialProfileId: { groupId: id, socialProfileId: profileId } },
+      });
+      isMember = !!m;
+    }
+    const data = { ...group, memberCount: group._count.members, isMember };
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error("Error getting group", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/groups/[id]/route.ts
+++ b/src/app/api/social/groups/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
 
 export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
-  const { id } = ctx.params;
+  const { id } = await ctx.params;
   const profileId = req.nextUrl.searchParams.get("profileId");
   try {
     const group = await prisma.runGroup.findUnique({

--- a/src/app/api/social/groups/route.ts
+++ b/src/app/api/social/groups/route.ts
@@ -38,7 +38,13 @@ export async function POST(req: NextRequest) {
     );
   }
   try {
-    const group = await prisma.runGroup.create({ data });
+    const group = await prisma.runGroup.create({
+      data,
+    });
+    // add creator as member
+    await prisma.runGroupMember.create({
+      data: { groupId: group.id, socialProfileId: group.ownerId },
+    });
     return NextResponse.json(group, { status: 201 });
   } catch (err) {
     console.error("Error creating group", err);

--- a/src/app/api/social/groups/route.ts
+++ b/src/app/api/social/groups/route.ts
@@ -5,7 +5,7 @@ export async function GET(req: NextRequest) {
   const profileId = req.nextUrl.searchParams.get("profileId");
   try {
     const groups = await prisma.runGroup.findMany({
-      include: { _count: { select: { members: true } } },
+      include: { _count: { select: { members: true, posts: true } } },
       orderBy: { createdAt: "desc" },
     });
     let memberships: Set<string> | null = null;
@@ -19,6 +19,7 @@ export async function GET(req: NextRequest) {
     const mapped = groups.map((g) => ({
       ...g,
       memberCount: g._count.members,
+      postCount: g._count.posts,
       isMember: memberships ? memberships.has(g.id) : undefined,
     }));
     return NextResponse.json(mapped);

--- a/src/app/api/social/groups/route.ts
+++ b/src/app/api/social/groups/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function GET() {
+  try {
+    const groups = await prisma.runGroup.findMany({
+      include: { _count: { select: { members: true } } },
+      orderBy: { createdAt: "desc" },
+    });
+    const mapped = groups.map((g) => ({
+      ...g,
+      memberCount: g._count.members,
+    }));
+    return NextResponse.json(mapped);
+  } catch (err) {
+    console.error("Error listing groups", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  if (!data.name || !data.ownerId) {
+    return NextResponse.json(
+      { error: "name and ownerId required" },
+      { status: 400 }
+    );
+  }
+  try {
+    const group = await prisma.runGroup.create({ data });
+    return NextResponse.json(group, { status: 201 });
+  } catch (err) {
+    console.error("Error creating group", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/social/profile/byUser/[id]/route.ts
+++ b/src/app/api/social/profile/byUser/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
 
 export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
-  const { id } = ctx.params;
+  const { id } = await ctx.params;
   try {
     const profile = await prisma.socialProfile.findUnique({
       where: { userId: id },

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import axios from "axios";
+import SocialFeed from "@components/social/SocialFeed";
+import { Button, Spinner } from "@components/ui";
+import type { RunGroup } from "@maratypes/social";
+
+export default function GroupPage({ params }: { params: { id: string } }) {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [group, setGroup] = useState<RunGroup | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchGroup = async () => {
+    try {
+      const { data } = await axios.get<RunGroup>(
+        `/api/social/groups/${params.id}?profileId=${session?.user?.id ?? ""}`
+      );
+      setGroup(data);
+    } catch {
+      setGroup(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchGroup();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.user?.id]);
+
+  const handleJoin = async () => {
+    if (!session?.user?.id) {
+      router.push("/login");
+      return;
+    }
+    await axios.post(`/api/social/groups/${params.id}/join`, {
+      profileId: session.user.id,
+    });
+    fetchGroup();
+  };
+
+  if (loading)
+    return (
+      <div className="w-full px-4 py-6 flex justify-center">
+        <Spinner className="h-4 w-4" />
+      </div>
+    );
+  if (!group) return <p className="w-full px-4 py-6">Group not found.</p>;
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">{group.name}</h1>
+          {!group.isMember && (
+            <Button onClick={handleJoin}>Join Group</Button>
+          )}
+        </div>
+        {group.description && <p>{group.description}</p>}
+        <SocialFeed groupId={group.id} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -8,17 +9,18 @@ import SocialFeed from "@components/social/SocialFeed";
 import { Button, Spinner, Card } from "@components/ui";
 import type { RunGroup } from "@maratypes/social";
 
-export default function GroupPage({ params }: { params: { id: string } }) {
+export default function GroupPage() {
   const { data: session } = useSession();
   const { profile, loading: profileLoading } = useSocialProfile();
   const router = useRouter();
+  const { id } = useParams() as { id: string };
   const [group, setGroup] = useState<RunGroup | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchGroup = async () => {
     try {
       const { data } = await axios.get<RunGroup>(
-        `/api/social/groups/${params.id}?profileId=${profile?.id ?? ""}`
+        `/api/social/groups/${id}?profileId=${profile?.id ?? ""}`
       );
       setGroup(data);
     } catch {
@@ -41,7 +43,7 @@ export default function GroupPage({ params }: { params: { id: string } }) {
       return;
     }
     if (!profile?.id) return;
-    await axios.post(`/api/social/groups/${params.id}/join`, {
+    await axios.post(`/api/social/groups/${id}/join`, {
       profileId: profile.id,
     });
     fetchGroup();

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useSession } from "next-auth/react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import axios from "axios";
 import SocialFeed from "@components/social/SocialFeed";
-import { Button, Spinner } from "@components/ui";
+import { Button, Spinner, Card } from "@components/ui";
 import type { RunGroup } from "@maratypes/social";
 
 export default function GroupPage({ params }: { params: { id: string } }) {
@@ -57,7 +57,7 @@ export default function GroupPage({ params }: { params: { id: string } }) {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-4">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold">{group.name}</h1>
           {!group.isMember && (
@@ -65,6 +65,27 @@ export default function GroupPage({ params }: { params: { id: string } }) {
           )}
         </div>
         {group.description && <p>{group.description}</p>}
+        <Card className="p-4 space-y-2">
+          <p className="text-sm text-foreground/60">
+            Created {new Date(group.createdAt).toLocaleDateString()}
+          </p>
+          <p className="text-sm">Members: {group.memberCount}</p>
+          {group.totalDistance !== undefined && (
+            <p className="text-sm">
+              Total Distance: {group.totalDistance.toFixed(2)} mi
+            </p>
+          )}
+          {group.members && group.members.length > 0 && (
+            <div>
+              <p className="font-semibold mb-1">Users</p>
+              <ul className="list-disc ml-6">
+                {group.members.map((m) => (
+                  <li key={m.id}>{m.username}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </Card>
         <SocialFeed groupId={group.id} />
       </main>
     </div>

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -75,16 +75,6 @@ export default function GroupPage({ params }: { params: { id: string } }) {
               Total Distance: {group.totalDistance.toFixed(2)} mi
             </p>
           )}
-          {group.members && group.members.length > 0 && (
-            <div>
-              <p className="font-semibold mb-1">Users</p>
-              <ul className="list-disc ml-6">
-                {group.members.map((m) => (
-                  <li key={m.id}>{m.username}</li>
-                ))}
-              </ul>
-            </div>
-          )}
         </Card>
         <SocialFeed groupId={group.id} />
       </main>

--- a/src/app/social/groups/new/page.tsx
+++ b/src/app/social/groups/new/page.tsx
@@ -1,0 +1,13 @@
+import CreateGroupForm from "@components/social/CreateGroupForm";
+
+export default function NewGroupPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex justify-center">
+          <CreateGroupForm />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/social/groups/page.tsx
+++ b/src/app/social/groups/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import { Button } from "@components/ui";
+
+export default function GroupsPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-4">
+        <h1 className="text-2xl font-bold">Run Groups</h1>
+        <Button asChild>
+          <Link href="/social/groups/new">Create Group</Link>
+        </Button>
+      </main>
+    </div>
+  );
+}

--- a/src/app/social/groups/page.tsx
+++ b/src/app/social/groups/page.tsx
@@ -49,7 +49,10 @@ export default function GroupsPage() {
                     <li key={g.id}>
                       <Link href={`/social/groups/${g.id}`} className="hover:underline">
                         {g.name}
-                      </Link>
+                      </Link>{" "}
+                      <span className="text-sm text-foreground/60">
+                        ({g.memberCount} members)
+                      </span>
                     </li>
                   ))}
                 </ul>
@@ -62,7 +65,10 @@ export default function GroupsPage() {
                   <li key={g.id}>
                     <Link href={`/social/groups/${g.id}`} className="hover:underline">
                       {g.name}
-                    </Link>
+                    </Link>{" "}
+                    <span className="text-sm text-foreground/60">
+                      ({g.memberCount} members)
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/src/app/social/groups/page.tsx
+++ b/src/app/social/groups/page.tsx
@@ -1,14 +1,74 @@
+"use client";
 import Link from "next/link";
-import { Button } from "@components/ui";
+import { useEffect, useState } from "react";
+import { useSocialProfile } from "@hooks/useSocialProfile";
+import { listGroups } from "@lib/api/social";
+import type { RunGroup } from "@maratypes/social";
+import { Button, Spinner } from "@components/ui";
 
 export default function GroupsPage() {
+  const { profile, loading: profileLoading } = useSocialProfile();
+  const [groups, setGroups] = useState<RunGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await listGroups(profile?.id);
+        setGroups(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (!profileLoading) load();
+  }, [profile?.id, profileLoading]);
+
+  const yourGroups = groups.filter((g) => g.isMember);
+  const otherGroups = groups.filter((g) => !g.isMember);
+
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-4">
-        <h1 className="text-2xl font-bold">Run Groups</h1>
-        <Button asChild>
-          <Link href="/social/groups/new">Create Group</Link>
-        </Button>
+      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Run Groups</h1>
+          <Button asChild>
+            <Link href="/social/groups/new">Create Group</Link>
+          </Button>
+        </div>
+        {loading ? (
+          <div className="flex justify-center py-4">
+            <Spinner className="h-4 w-4" />
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {yourGroups.length > 0 && (
+              <div>
+                <h2 className="text-xl font-semibold mb-2">Your Groups</h2>
+                <ul className="list-disc ml-6 space-y-1">
+                  {yourGroups.map((g) => (
+                    <li key={g.id}>
+                      <Link href={`/social/groups/${g.id}`} className="hover:underline">
+                        {g.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div>
+              <h2 className="text-xl font-semibold mb-2">All Groups</h2>
+              <ul className="list-disc ml-6 space-y-1">
+                {otherGroups.map((g) => (
+                  <li key={g.id}>
+                    <Link href={`/social/groups/${g.id}`} className="hover:underline">
+                      {g.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -43,6 +43,7 @@ export default function Navbar() {
     { href: "/social", label: "Social" },
     { href: "/social/feed", label: "Social Feed" },
     { href: "/social/search", label: "Find Runners" },
+    { href: "/social/groups", label: "Groups" }
   ];
 
   return (

--- a/src/components/__tests__/CreateSocialPost.test.tsx
+++ b/src/components/__tests__/CreateSocialPost.test.tsx
@@ -55,6 +55,32 @@ describe("CreateSocialPost", () => {
     expect(await screen.findByText(/posted!/i)).toBeInTheDocument();
   });
 
+  it("includes groupId when provided", async () => {
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1", userId: "u1" } });
+    mockedCreate.mockResolvedValue({ id: "post1" } as any);
+    mockedListRuns.mockResolvedValue([
+      {
+        id: "r1",
+        userId: "u1",
+        date: new Date().toISOString(),
+        distance: 3,
+        distanceUnit: "miles",
+        duration: "00:20:00",
+      } as any,
+    ]);
+    const user = userEvent.setup();
+
+    render(<CreateSocialPost groupId="g1" />);
+
+    await waitFor(() => expect(mockedListRuns).toHaveBeenCalled());
+    await user.selectOptions(await screen.findByLabelText(/run/i), "r1");
+    await user.click(screen.getByRole("button", { name: /post/i }));
+
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: "g1" })
+    );
+  });
+
   it("shows error when required fields missing", async () => {
     mockedUseProfile.mockReturnValue({ profile: { id: "p1", userId: "u1" } });
     mockedListRuns.mockResolvedValue([

--- a/src/components/__tests__/SocialFeed.test.tsx
+++ b/src/components/__tests__/SocialFeed.test.tsx
@@ -10,7 +10,12 @@ jest.mock("next-auth/react", () => ({ useSession: jest.fn() }));
 jest.mock("@hooks/useSocialProfile", () => ({ useSocialProfile: jest.fn() }));
 jest.mock("axios");
 
-jest.mock("@components/social/CreateSocialPost", () => ({ __esModule: true, default: () => <div data-testid="create-post" /> }));
+const MockCreatePost = jest.fn(() => <div data-testid="create-post" />);
+jest.mock("@components/social/CreateSocialPost", () => ({
+  __esModule: true,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (props: Record<string, any>) => MockCreatePost(props),
+}));
 
 const mockedSession = useSession as jest.Mock;
 const mockedUseProfile = useSocialProfile as jest.Mock;
@@ -52,6 +57,9 @@ describe("SocialFeed", () => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         "/api/social/groups/g1/posts?profileId=p1"
       )
+    );
+    expect(MockCreatePost).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: "g1" })
     );
   });
 });

--- a/src/components/__tests__/SocialFeed.test.tsx
+++ b/src/components/__tests__/SocialFeed.test.tsx
@@ -40,4 +40,18 @@ describe("SocialFeed", () => {
     expect(await screen.findByText(/tester/)).toBeInTheDocument();
     expect(screen.getByText(/3 mi in 00:20:00/)).toBeInTheDocument();
   });
+
+  it("loads group feed when groupId passed", async () => {
+    mockedSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    mockedUseProfile.mockReturnValue({ profile: { id: "p1" }, loading: false });
+    mockedAxios.get.mockResolvedValue({ data: [] });
+
+    render(<SocialFeed groupId="g1" />);
+
+    await waitFor(() =>
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        "/api/social/groups/g1/posts?profileId=p1"
+      )
+    );
+  });
 });

--- a/src/components/social/CreateGroupForm.tsx
+++ b/src/components/social/CreateGroupForm.tsx
@@ -1,12 +1,14 @@
 "use client";
 import { useState, FormEvent } from "react";
 import { useSession } from "next-auth/react";
+import { useSocialProfile } from "@hooks/useSocialProfile";
 import { createGroup } from "@lib/api/social";
 import { Card, Button, Switch } from "@components/ui";
 import { TextField, TextAreaField } from "@components/ui/FormField";
 
 export default function CreateGroupForm() {
   const { data: session } = useSession();
+  const { profile } = useSocialProfile();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [isPrivate, setIsPrivate] = useState(false);
@@ -17,7 +19,11 @@ export default function CreateGroupForm() {
     e.preventDefault();
     setError("");
     setSuccess("");
-    if (!session?.user?.id || !name) {
+    if (!session?.user?.id) {
+      setError("Login required");
+      return;
+    }
+    if (!profile?.id || !name) {
       setError("Group name required");
       return;
     }
@@ -26,7 +32,7 @@ export default function CreateGroupForm() {
         name,
         description: description || undefined,
         private: isPrivate,
-        ownerId: session.user.id,
+        ownerId: profile.id,
       });
       setSuccess("Group created!");
       setName("");

--- a/src/components/social/CreateGroupForm.tsx
+++ b/src/components/social/CreateGroupForm.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState, FormEvent } from "react";
+import { useSession } from "next-auth/react";
+import { createGroup } from "@lib/api/social";
+import { Card, Button, Switch } from "@components/ui";
+import { TextField, TextAreaField } from "@components/ui/FormField";
+
+export default function CreateGroupForm() {
+  const { data: session } = useSession();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    if (!session?.user?.id || !name) {
+      setError("Group name required");
+      return;
+    }
+    try {
+      await createGroup({
+        name,
+        description: description || undefined,
+        private: isPrivate,
+        ownerId: session.user.id,
+      });
+      setSuccess("Group created!");
+      setName("");
+      setDescription("");
+      setIsPrivate(false);
+    } catch {
+      setError("Failed to create group");
+    }
+  };
+
+  return (
+    <Card className="p-6 w-full max-w-md">
+      <h2 className="text-2xl font-semibold mb-4">Create Run Group</h2>
+      {error && <p className="text-brand-orange-dark mb-2">{error}</p>}
+      {success && <p className="text-primary mb-2">{success}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          label="Name"
+          name="name"
+          value={name}
+          onChange={(_n, v) => setName(String(v))}
+          required
+        />
+        <TextAreaField
+          label="Description"
+          name="description"
+          value={description}
+          onChange={(_n, v) => setDescription(String(v))}
+          rows={2}
+        />
+        <div className="flex items-center gap-2">
+          <Switch
+            id="private"
+            checked={isPrivate}
+            onCheckedChange={(v) => setIsPrivate(v)}
+          />
+          <label htmlFor="private" className="text-sm">
+            Private group
+          </label>
+        </div>
+        <div className="flex justify-end">
+          <Button type="submit">Create Group</Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/social/CreateSocialPost.tsx
+++ b/src/components/social/CreateSocialPost.tsx
@@ -10,9 +10,10 @@ import type { Run } from "@maratypes/run";
 
 interface Props {
   onCreated?: () => void;
+  groupId?: string;
 }
 
-export default function CreateSocialPost({ onCreated }: Props) {
+export default function CreateSocialPost({ onCreated, groupId }: Props) {
   const { profile } = useSocialProfile();
   const [runs, setRuns] = useState<Run[]>([]);
   const [selectedRunId, setSelectedRunId] = useState("");
@@ -57,6 +58,7 @@ export default function CreateSocialPost({ onCreated }: Props) {
         time: run.duration,
         caption: caption || undefined,
         photoUrl: photoUrl || undefined,
+        groupId,
       });
       setSuccess("Posted!");
       setSelectedRunId("");

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -26,7 +26,7 @@ export default function SocialFeed({ groupId }: Props) {
     if (!session?.user?.id) return;
     try {
       const url = groupId
-        ? `/api/social/groups/${groupId}/posts?profileId=${session.user.id}`
+        ? `/api/social/groups/${groupId}/posts?profileId=${profile?.id ?? ""}`
         : `/api/social/feed?userId=${session.user.id}`;
       const { data } = await axios.get<RunPost[]>(url);
       setPosts(data);
@@ -40,7 +40,7 @@ export default function SocialFeed({ groupId }: Props) {
   useEffect(() => {
     fetchFeed();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session?.user?.id, groupId]);
+  }, [session?.user?.id, profile?.id, groupId]);
 
   if (!session?.user?.id) return <p>Please log in to view your feed.</p>;
   if (profileLoading || loading)

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -11,7 +11,11 @@ import { Button, Dialog, DialogContent, Spinner } from "@components/ui";
 import Link from "next/link";
 import Image from "next/image";
 
-export default function SocialFeed() {
+interface Props {
+  groupId?: string;
+}
+
+export default function SocialFeed({ groupId }: Props) {
   const { data: session } = useSession();
   const { profile, loading: profileLoading } = useSocialProfile();
   const [posts, setPosts] = useState<RunPost[]>([]);
@@ -21,9 +25,10 @@ export default function SocialFeed() {
   const fetchFeed = async () => {
     if (!session?.user?.id) return;
     try {
-      const { data } = await axios.get<RunPost[]>(
-        `/api/social/feed?userId=${session.user.id}`
-      );
+      const url = groupId
+        ? `/api/social/groups/${groupId}/posts?profileId=${session.user.id}`
+        : `/api/social/feed?userId=${session.user.id}`;
+      const { data } = await axios.get<RunPost[]>(url);
       setPosts(data);
     } catch (err) {
       console.error(err);
@@ -35,7 +40,7 @@ export default function SocialFeed() {
   useEffect(() => {
     fetchFeed();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session?.user?.id]);
+  }, [session?.user?.id, groupId]);
 
   if (!session?.user?.id) return <p>Please log in to view your feed.</p>;
   if (profileLoading || loading)

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -61,7 +61,7 @@ export default function SocialFeed({ groupId }: Props) {
 
   return (
     <div className="space-y-6">
-      <CreateSocialPost onCreated={fetchFeed} />
+      <CreateSocialPost onCreated={fetchFeed} groupId={groupId} />
       {posts.length === 0 && <p>No posts yet.</p>}
       {posts.map((post) => (
         <div key={post.id} className="border rounded-md p-4">

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -53,10 +53,36 @@ describe("social api helpers", () => {
   });
 
   it("createPost posts data", async () => {
-    const post: RunPost = { id: "1", socialProfileId: "p", distance: 1, time: "00:10:00", createdAt: new Date(), updatedAt: new Date() } as RunPost;
+    const post: RunPost = {
+      id: "1",
+      socialProfileId: "p",
+      distance: 1,
+      time: "00:10:00",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as RunPost;
     mockedAxios.post.mockResolvedValue({ data: post });
     const result = await createPost({ distance: 1 });
     expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/posts", { distance: 1 });
+    expect(result).toEqual(post);
+  });
+
+  it("createPost posts to group when groupId provided", async () => {
+    const post: RunPost = {
+      id: "1",
+      socialProfileId: "p",
+      distance: 1,
+      time: "00:10:00",
+      groupId: "g1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as RunPost;
+    mockedAxios.post.mockResolvedValue({ data: post });
+    const result = await createPost({ distance: 1, groupId: "g1" });
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "/api/social/groups/g1/posts",
+      { distance: 1 }
+    );
     expect(result).toEqual(post);
   });
 

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -13,8 +13,9 @@ import {
   createGroup,
   joinGroup,
   listGroupPosts,
+  listGroups,
 } from "../social";
-import type { RunPost, Comment } from "@maratypes/social";
+import type { RunPost, Comment, RunGroup } from "@maratypes/social";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -138,5 +139,15 @@ describe("social api helpers", () => {
       "/api/social/groups/g1/posts?profileId=p1"
     );
     expect(result).toEqual(posts);
+  });
+
+  it("listGroups gets data", async () => {
+    const groups: RunGroup[] = [];
+    mockedAxios.get.mockResolvedValue({ data: groups });
+    const result = await listGroups("p1");
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "/api/social/groups?profileId=p1"
+    );
+    expect(result).toEqual(groups);
   });
 });

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -10,6 +10,9 @@ import {
   unlikePost,
   addComment,
   listComments,
+  createGroup,
+  joinGroup,
+  listGroupPosts,
 } from "../social";
 import type { RunPost, Comment } from "@maratypes/social";
 
@@ -106,5 +109,34 @@ describe("social api helpers", () => {
       "/api/social/posts/p/comments"
     );
     expect(result).toEqual(comments);
+  });
+
+  it("createGroup posts data", async () => {
+    mockedAxios.post.mockResolvedValue({ data: { id: "g1" } });
+    const result = await createGroup({ name: "Test", ownerId: "p1" });
+    expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/groups", {
+      name: "Test",
+      ownerId: "p1",
+    });
+    expect(result).toEqual({ id: "g1" });
+  });
+
+  it("joinGroup posts data", async () => {
+    mockedAxios.post.mockResolvedValue({ data: {} });
+    await joinGroup("g1", "p1");
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "/api/social/groups/g1/join",
+      { profileId: "p1" }
+    );
+  });
+
+  it("listGroupPosts gets data", async () => {
+    const posts: RunPost[] = [];
+    mockedAxios.get.mockResolvedValue({ data: posts });
+    const result = await listGroupPosts("g1", "p1");
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "/api/social/groups/g1/posts?profileId=p1"
+    );
+    expect(result).toEqual(posts);
   });
 });

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -39,9 +39,17 @@ export const isFollowing = async (
 };
 
 export const createPost = async (
-  data: Partial<RunPost>
+  data: Partial<RunPost> & { groupId?: string }
 ): Promise<RunPost> => {
-  const { data: post } = await axios.post<RunPost>("/api/social/posts", data);
+  const { groupId, ...rest } = data;
+  if (groupId) {
+    const { data: post } = await axios.post<RunPost>(
+      `/api/social/groups/${groupId}/posts`,
+      rest
+    );
+    return post;
+  }
+  const { data: post } = await axios.post<RunPost>("/api/social/posts", rest);
   return post;
 };
 

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -121,3 +121,13 @@ export const listGroupPosts = async (
   const { data: posts } = await axios.get<RunPost[]>(url);
   return posts;
 };
+
+export const listGroups = async (
+  profileId?: string
+): Promise<RunGroup[]> => {
+  const url = profileId
+    ? `/api/social/groups?profileId=${profileId}`
+    : `/api/social/groups`;
+  const { data: groups } = await axios.get<RunGroup[]>(url);
+  return groups;
+};

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import type { SocialProfile, RunPost, Comment } from "@maratypes/social";
+import type { RunGroup } from "@maratypes/social";
 
 export const createSocialProfile = async (
   data: Pick<SocialProfile, "userId" | "username"> & Partial<SocialProfile>
@@ -91,4 +92,32 @@ export const listComments = async (postId: string): Promise<Comment[]> => {
     `/api/social/posts/${postId}/comments`
   );
   return comments;
+};
+
+export const createGroup = async (
+  data: Pick<RunGroup, "name" | "ownerId"> & Partial<RunGroup>
+): Promise<RunGroup> => {
+  const { data: group } = await axios.post<RunGroup>(
+    "/api/social/groups",
+    data
+  );
+  return group;
+};
+
+export const joinGroup = async (
+  groupId: string,
+  profileId: string
+): Promise<void> => {
+  await axios.post(`/api/social/groups/${groupId}/join`, { profileId });
+};
+
+export const listGroupPosts = async (
+  groupId: string,
+  profileId?: string
+): Promise<RunPost[]> => {
+  const url = profileId
+    ? `/api/social/groups/${groupId}/posts?profileId=${profileId}`
+    : `/api/social/groups/${groupId}/posts`;
+  const { data: posts } = await axios.get<RunPost[]>(url);
+  return posts;
 };

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -68,6 +68,11 @@ export interface RunGroup {
   updatedAt: Date;
   memberCount?: number;
   isMember?: boolean;
+  postCount?: number;
+  /** Total distance from all members' runs */
+  totalDistance?: number;
+  /** Social profiles of members */
+  members?: SocialProfile[];
 }
 
 export interface RunGroupMember {

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -17,6 +17,7 @@ export interface SocialProfile {
 export interface RunPost {
   id: string;
   socialProfileId: string;
+  groupId?: string | null;
   distance: number;
   time: string;
   caption?: string | null;
@@ -55,4 +56,22 @@ export interface Like {
   postId: string;
   socialProfileId: string;
   createdAt: Date;
+}
+
+export interface RunGroup {
+  id: string;
+  name: string;
+  description?: string | null;
+  private: boolean;
+  ownerId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  memberCount?: number;
+  isMember?: boolean;
+}
+
+export interface RunGroupMember {
+  groupId: string;
+  socialProfileId: string;
+  joinedAt: Date;
 }


### PR DESCRIPTION
## Summary
- allow posts to belong to a group and define group data in Prisma
- support run groups via API (create, join, posts, details)
- expose helpers for creating and joining groups and fetching posts
- create forms and pages for groups
- update SocialFeed to optionally load group feed
- test new API helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f5617deec8324bf7169254d1cd272