### PR TITLE
Improve run group pages layout

### DIFF
--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -58,15 +58,17 @@ export default function GroupPage() {
   if (!group) return <p className="w-full px-4 py-6">Group not found.</p>;
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 max-w-screen-lg py-8 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold">{group.name}</h1>
           {!group.isMember && (
             <Button onClick={handleJoin}>Join Group</Button>
           )}
         </div>
-        {group.description && <p>{group.description}</p>}
+        {group.description && (
+          <p className="text-foreground/70">{group.description}</p>
+        )}
         <Card className="p-4 space-y-2">
           <p className="text-sm text-foreground/60">
             Created {new Date(group.createdAt).toLocaleDateString()}

--- a/src/app/social/groups/new/page.tsx
+++ b/src/app/social/groups/new/page.tsx
@@ -2,11 +2,9 @@ import CreateGroupForm from "@components/social/CreateGroupForm";
 
 export default function NewGroupPage() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6">
-        <div className="flex justify-center">
-          <CreateGroupForm />
-        </div>
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 max-w-screen-lg py-8 flex justify-center">
+        <CreateGroupForm />
       </main>
     </div>
   );

--- a/src/app/social/groups/page.tsx
+++ b/src/app/social/groups/page.tsx
@@ -5,6 +5,7 @@ import { useSocialProfile } from "@hooks/useSocialProfile";
 import { listGroups } from "@lib/api/social";
 import type { RunGroup } from "@maratypes/social";
 import { Button, Spinner } from "@components/ui";
+import GroupCard from "@components/social/GroupCard";
 
 export default function GroupsPage() {
   const { profile, loading: profileLoading } = useSocialProfile();
@@ -27,8 +28,8 @@ export default function GroupsPage() {
   const otherGroups = groups.filter((g) => !g.isMember);
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <main className="flex-grow w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 max-w-screen-lg py-8 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold">Run Groups</h1>
           <Button asChild>
@@ -40,38 +41,24 @@ export default function GroupsPage() {
             <Spinner className="h-4 w-4" />
           </div>
         ) : (
-          <div className="space-y-6">
+          <div className="space-y-8">
             {yourGroups.length > 0 && (
-              <div>
-                <h2 className="text-xl font-semibold mb-2">Your Groups</h2>
-                <ul className="list-disc ml-6 space-y-1">
+              <div className="space-y-4">
+                <h2 className="text-xl font-semibold">Your Groups</h2>
+                <div className="grid md:grid-cols-2 gap-4">
                   {yourGroups.map((g) => (
-                    <li key={g.id}>
-                      <Link href={`/social/groups/${g.id}`} className="hover:underline">
-                        {g.name}
-                      </Link>{" "}
-                      <span className="text-sm text-foreground/60">
-                        ({g.memberCount} members)
-                      </span>
-                    </li>
+                    <GroupCard key={g.id} group={g} />
                   ))}
-                </ul>
+                </div>
               </div>
             )}
-            <div>
-              <h2 className="text-xl font-semibold mb-2">All Groups</h2>
-              <ul className="list-disc ml-6 space-y-1">
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold">All Groups</h2>
+              <div className="grid md:grid-cols-2 gap-4">
                 {otherGroups.map((g) => (
-                  <li key={g.id}>
-                    <Link href={`/social/groups/${g.id}`} className="hover:underline">
-                      {g.name}
-                    </Link>{" "}
-                    <span className="text-sm text-foreground/60">
-                      ({g.memberCount} members)
-                    </span>
-                  </li>
+                  <GroupCard key={g.id} group={g} />
                 ))}
-              </ul>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/social/GroupCard.tsx
+++ b/src/components/social/GroupCard.tsx
@@ -1,0 +1,29 @@
+"use client";
+import Link from "next/link";
+import { Card, Badge } from "@components/ui";
+import type { RunGroup } from "@maratypes/social";
+
+interface Props {
+  group: RunGroup;
+}
+
+export default function GroupCard({ group }: Props) {
+  return (
+    <Card className="p-4 flex flex-col gap-2">
+      <div className="flex justify-between items-start">
+        <div>
+          <Link href={`/social/groups/${group.id}`} className="font-semibold text-lg hover:underline">
+            {group.name}
+          </Link>
+          {group.description && (
+            <p className="text-sm text-foreground/70 break-words">{group.description}</p>
+          )}
+        </div>
+        <div className="flex flex-col items-end text-sm text-foreground/60 gap-1">
+          <span>{group.memberCount ?? 0} members</span>
+          {group.private && <Badge variant="secondary">Private</Badge>}
+        </div>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GroupCard` component
- polish group listing with cards and grid
- refine individual group page spacing
- update new group page layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f7c6e9bc883249fb3b2fa9de4457f