### PR TITLE
Improve social group pages

### DIFF
--- a/src/app/api/social/groups/[id]/join/route.ts
+++ b/src/app/api/social/groups/[id]/join/route.ts
@@ -19,3 +19,23 @@ export async function POST(req: NextRequest, ctx: { params: { id: string } }) {
     return NextResponse.json({ error: "Failed" }, { status: 500 });
   }
 }
+
+export async function DELETE(
+  req: NextRequest,
+  ctx: { params: { id: string } }
+) {
+  const { id } = ctx.params;
+  const { profileId } = await req.json();
+  if (!profileId) {
+    return NextResponse.json({ error: "profileId required" }, { status: 400 });
+  }
+  try {
+    await prisma.runGroupMember.delete({
+      where: { groupId_socialProfileId: { groupId: id, socialProfileId: profileId } },
+    });
+    return NextResponse.json({});
+  } catch (err) {
+    console.error("Error leaving group", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from "next-auth/react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import axios from "axios";
 import SocialFeed from "@components/social/SocialFeed";
+import GroupMembers from "@components/social/GroupMembers";
 import { Button, Spinner, Card } from "@components/ui";
 import type { RunGroup } from "@maratypes/social";
 
@@ -49,6 +50,14 @@ export default function GroupPage() {
     fetchGroup();
   };
 
+  const handleLeave = async () => {
+    if (!profile?.id) return;
+    await axios.delete(`/api/social/groups/${id}/join`, {
+      data: { profileId: profile.id },
+    });
+    fetchGroup();
+  };
+
   if (loading)
     return (
       <div className="w-full px-4 py-6 flex justify-center">
@@ -62,7 +71,11 @@ export default function GroupPage() {
       <main className="container mx-auto px-4 max-w-screen-lg py-8 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold">{group.name}</h1>
-          {!group.isMember && (
+          {group.isMember ? (
+            <Button onClick={handleLeave} variant="secondary">
+              Leave Group
+            </Button>
+          ) : (
             <Button onClick={handleJoin}>Join Group</Button>
           )}
         </div>
@@ -80,6 +93,7 @@ export default function GroupPage() {
             </p>
           )}
         </Card>
+        {group.members && <GroupMembers members={group.members} />}
         <SocialFeed groupId={group.id} />
       </main>
     </div>

--- a/src/components/social/GroupMembers.tsx
+++ b/src/components/social/GroupMembers.tsx
@@ -1,0 +1,34 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+import type { SocialProfile } from "@maratypes/social";
+import { Card } from "@components/ui";
+
+interface Props {
+  members: SocialProfile[];
+}
+
+export default function GroupMembers({ members }: Props) {
+  if (members.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xl font-semibold">Members</h2>
+      <div className="grid sm:grid-cols-2 gap-4">
+        {members.map((m) => (
+          <Card key={m.id} className="p-3 flex items-center gap-3">
+            <Image
+              src={m.avatarUrl || "/default_profile.png"}
+              alt={m.username}
+              width={32}
+              height={32}
+              className="w-8 h-8 rounded-full object-cover"
+            />
+            <Link href={`/u/${m.username}`} className="font-semibold hover:underline">
+              {m.name ?? m.username}
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -12,6 +12,7 @@ import {
   listComments,
   createGroup,
   joinGroup,
+  leaveGroup,
   listGroupPosts,
   listGroups,
 } from "../social";
@@ -154,6 +155,15 @@ describe("social api helpers", () => {
     expect(mockedAxios.post).toHaveBeenCalledWith(
       "/api/social/groups/g1/join",
       { profileId: "p1" }
+    );
+  });
+
+  it("leaveGroup deletes data", async () => {
+    mockedAxios.delete.mockResolvedValue({ data: {} });
+    await leaveGroup("g1", "p1");
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      "/api/social/groups/g1/join",
+      { data: { profileId: "p1" } }
     );
   });
 

--- a/src/lib/api/social/index.ts
+++ b/src/lib/api/social/index.ts
@@ -119,6 +119,15 @@ export const joinGroup = async (
   await axios.post(`/api/social/groups/${groupId}/join`, { profileId });
 };
 
+export const leaveGroup = async (
+  groupId: string,
+  profileId: string
+): Promise<void> => {
+  await axios.delete(`/api/social/groups/${groupId}/join`, {
+    data: { profileId },
+  });
+};
+
 export const listGroupPosts = async (
   groupId: string,
   profileId?: string


### PR DESCRIPTION
## Summary
- add new `GroupMembers` component to list group members
- show join/leave buttons on the group page and render member list
- support leaving groups via API and client helpers
- test new API helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f7e838eb883248e4b260d5843f956