### PR TITLE
Fix default avatar background contrast

### DIFF
--- a/src/components/DefaultAvatar.tsx
+++ b/src/components/DefaultAvatar.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import React from "react";
+import { cn } from "@lib/utils/cn";
 
 export interface DefaultAvatarProps {
   /** Size of the avatar circle */
@@ -14,7 +15,10 @@ export default function DefaultAvatar({ size = 32, className = "" }: DefaultAvat
       alt="Default avatar"
       width={size}
       height={size}
-      className={`rounded-full object-cover ${className}`}
+      className={cn(
+        "rounded-full object-cover border border-brand-to bg-brand-from",
+        className,
+      )}
     />
   );
 }

--- a/src/components/social/CommentSection.tsx
+++ b/src/components/social/CommentSection.tsx
@@ -82,7 +82,7 @@ export default function CommentSection({
                   alt={c.socialProfile?.username || "avatar"}
                   width={24}
                   height={24}
-                  className="w-6 h-6 rounded-full object-cover"
+                  className="w-6 h-6 rounded-full object-cover border border-brand-to bg-brand-from"
                 />
                 <p>
                   <span className="font-semibold">{c.socialProfile?.username}</span>{" "}

--- a/src/components/social/ProfileInfoCard.tsx
+++ b/src/components/social/ProfileInfoCard.tsx
@@ -26,7 +26,7 @@ export default function ProfileInfoCard({ profile, user, isSelf }: Props) {
         alt={profile.username}
         width={64}
         height={64}
-        className="w-16 h-16 rounded-full object-cover"
+        className="w-16 h-16 rounded-full object-cover border border-brand-to bg-brand-from"
       />
       <div className="flex-1 min-w-0 break-words">
         <h2 className="text-xl font-bold truncate">

--- a/src/components/social/ProfileSearch.tsx
+++ b/src/components/social/ProfileSearch.tsx
@@ -101,7 +101,7 @@ export default function ProfileSearch() {
                 alt={p.username}
                 width={40}
                 height={40}
-                className="w-10 h-10 rounded-full object-cover"
+                className="w-10 h-10 rounded-full object-cover border border-brand-to bg-brand-from"
               />
               <div>
                 <a href={`/u/${p.username}`} className="font-semibold">

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -68,7 +68,7 @@ export default function SocialFeed() {
               alt={post.socialProfile?.username || "avatar"}
               width={32}
               height={32}
-              className="w-8 h-8 rounded-full object-cover"
+              className="w-8 h-8 rounded-full object-cover border border-brand-to bg-brand-from"
             />
             {post.socialProfile?.username && (
               <Link


### PR DESCRIPTION
## Summary
- ensure default avatars include `border border-brand-to bg-brand-from`
- update `DefaultAvatar` component with brand styling
- adjust social components that directly use the fallback avatar

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f8c09ce888324bfc68ccec9c18d34