### PR TITLE
Improve group member display

### DIFF
--- a/src/components/social/GroupMembers.tsx
+++ b/src/components/social/GroupMembers.tsx
@@ -1,6 +1,5 @@
 "use client";
 import Image from "next/image";
-import Link from "next/link";
 import type { SocialProfile } from "@maratypes/social";
 import { Card } from "@components/ui";
 
@@ -10,24 +9,23 @@ interface Props {
 
 export default function GroupMembers({ members }: Props) {
   if (members.length === 0) return null;
+  const visible = members.slice(0, 5);
   return (
     <div className="space-y-2">
       <h2 className="text-xl font-semibold">Members</h2>
-      <div className="grid sm:grid-cols-2 gap-4">
-        {members.map((m) => (
-          <Card key={m.id} className="p-3 flex items-center gap-3">
+      <div className="flex items-center gap-2">
+        {visible.map((m) => (
+          <Card key={m.id} className="p-1 rounded-full">
             <Image
-              src={m.avatarUrl || "/default_profile.png"}
+              src={m.user?.avatarUrl || m.profilePhoto || m.avatarUrl || "/default_profile.png"}
               alt={m.username}
               width={32}
               height={32}
               className="w-8 h-8 rounded-full object-cover"
             />
-            <Link href={`/u/${m.username}`} className="font-semibold hover:underline">
-              {m.name ?? m.username}
-            </Link>
           </Card>
         ))}
+        {members.length > 5 && <span className="text-xl">...</span>}
       </div>
     </div>
   );

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -5,6 +5,9 @@ export interface SocialProfile {
   bio?: string | null;
   profilePhoto?: string | null;
   avatarUrl?: string | null;
+  user?: {
+    avatarUrl?: string | null;
+  };
   createdAt: Date;
   updatedAt: Date;
   name?: string | null;


### PR DESCRIPTION
## Summary
- show only five profile pictures for group members
- add avatar reference in `SocialProfile` type

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f8b9f92fc83248561cdceef42b217