### PR TITLE
Limit results on social pages

### DIFF
--- a/src/app/api/social/feed/route.ts
+++ b/src/app/api/social/feed/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
+import { FEED_POST_LIMIT } from "@lib/socialLimits";
 
 export async function GET(req: NextRequest) {
   const userId = req.nextUrl.searchParams.get("userId");
@@ -33,6 +34,7 @@ export async function GET(req: NextRequest) {
         },
       },
       orderBy: { createdAt: "desc" },
+      take: FEED_POST_LIMIT,
     });
 
     const mapped = posts.map((p) => ({

--- a/src/app/api/social/groups/[id]/posts/route.ts
+++ b/src/app/api/social/groups/[id]/posts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
+import { GROUP_POST_LIMIT } from "@lib/socialLimits";
 
 export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
   const { id } = ctx.params;
@@ -15,6 +16,7 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
           : undefined,
       },
       orderBy: { createdAt: "desc" },
+      take: GROUP_POST_LIMIT,
     });
     const mapped = posts.map((p) => ({
       id: p.id,

--- a/src/app/api/social/groups/route.ts
+++ b/src/app/api/social/groups/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
+import { GROUP_LIST_LIMIT } from "@lib/socialLimits";
 
 export async function GET(req: NextRequest) {
   const profileId = req.nextUrl.searchParams.get("profileId");
@@ -7,6 +8,7 @@ export async function GET(req: NextRequest) {
     const groups = await prisma.runGroup.findMany({
       include: { _count: { select: { members: true, posts: true } } },
       orderBy: { createdAt: "desc" },
+      take: GROUP_LIST_LIMIT,
     });
     let memberships: Set<string> | null = null;
     if (profileId) {

--- a/src/app/api/social/posts/[id]/comments/route.ts
+++ b/src/app/api/social/posts/[id]/comments/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
+import { COMMENT_LIMIT } from "@lib/socialLimits";
 
 export async function POST(req: NextRequest, ctx: { params: { id: string } }) {
   const { socialProfileId, text } = await req.json();
@@ -22,6 +23,7 @@ export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
       where: { postId: id },
       include: { socialProfile: true },
       orderBy: { createdAt: "asc" },
+      take: COMMENT_LIMIT,
     });
     return NextResponse.json(comments);
   } catch (err) {

--- a/src/app/api/social/posts/route.ts
+++ b/src/app/api/social/posts/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@lib/prisma";
+import { PROFILE_POST_LIMIT } from "@lib/socialLimits";
 
 export async function GET() {
   try {
     const posts = await prisma.runPost.findMany({
       include: { socialProfile: true },
       orderBy: { createdAt: "desc" },
+      take: PROFILE_POST_LIMIT,
     });
     return NextResponse.json(posts);
   } catch (err) {

--- a/src/app/api/social/profile/[username]/posts/route.ts
+++ b/src/app/api/social/profile/[username]/posts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@lib/prisma";
+import { PROFILE_POST_LIMIT } from "@lib/socialLimits";
 
 export async function GET(_req: NextRequest, ctx: { params: { username: string } }) {
   const { username } = ctx.params;
@@ -10,6 +11,7 @@ export async function GET(_req: NextRequest, ctx: { params: { username: string }
       where: { socialProfileId: profile.id },
       include: { _count: { select: { likes: true, comments: true } } },
       orderBy: { createdAt: "desc" },
+      take: PROFILE_POST_LIMIT,
     });
     return NextResponse.json(posts);
   } catch (err) {

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -8,6 +8,7 @@ import LikeButton from "@components/social/LikeButton";
 import CommentSection from "@components/social/CommentSection";
 import { Card } from "@components/ui";
 import { prisma } from "@lib/prisma";
+import { PROFILE_POST_LIMIT } from "@lib/socialLimits";
 
 async function getProfileData(username: string) {
   const profile = await prisma.socialProfile.findUnique({
@@ -36,6 +37,7 @@ async function getProfileData(username: string) {
     where: { socialProfileId: profile.id },
     include: { _count: { select: { likes: true, comments: true } } },
     orderBy: { createdAt: "desc" },
+    take: PROFILE_POST_LIMIT,
   });
   const likeActivity = await prisma.like.count({ where: { socialProfileId: profile.id } });
   const commentActivity = await prisma.comment.count({ where: { socialProfileId: profile.id } });

--- a/src/lib/socialLimits.ts
+++ b/src/lib/socialLimits.ts
@@ -1,0 +1,6 @@
+export const FEED_POST_LIMIT = 20;
+export const GROUP_POST_LIMIT = 20;
+export const PROFILE_POST_LIMIT = 20;
+export const COMMENT_LIMIT = 50;
+export const GROUP_LIST_LIMIT = 50;
+


### PR DESCRIPTION
## Summary
- add `src/lib/socialLimits.ts` constants for controlling counts
- limit posts in feed, groups, profile pages
- limit groups and comments

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f90f3364c8324ba8027a18b90a6ea