### PR TITLE
Add group image support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -237,6 +237,7 @@ model RunGroup {
   id          String   @id @default(uuid())
   name        String
   description String?
+  imageUrl    String?
   private     Boolean  @default(false)
   ownerId     String
   createdAt   DateTime @default(now())

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -82,6 +82,14 @@ export default function GroupPage() {
         {group.description && (
           <p className="text-foreground/70">{group.description}</p>
         )}
+        {group.imageUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={group.imageUrl}
+            alt={group.name}
+            className="w-32 h-32 object-cover rounded-md"
+          />
+        )}
         <Card className="p-4 space-y-2">
           <p className="text-sm text-foreground/60">
             Created {new Date(group.createdAt).toLocaleDateString()}

--- a/src/components/social/CreateGroupForm.tsx
+++ b/src/components/social/CreateGroupForm.tsx
@@ -3,7 +3,7 @@ import { useState, FormEvent } from "react";
 import { useSession } from "next-auth/react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import { createGroup } from "@lib/api/social";
-import { Card, Button, Switch } from "@components/ui";
+import { Card, Button, Switch, PhotoUpload } from "@components/ui";
 import { TextField, TextAreaField } from "@components/ui/FormField";
 
 export default function CreateGroupForm() {
@@ -11,6 +11,7 @@ export default function CreateGroupForm() {
   const { profile } = useSocialProfile();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
   const [isPrivate, setIsPrivate] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
@@ -31,12 +32,14 @@ export default function CreateGroupForm() {
       await createGroup({
         name,
         description: description || undefined,
+        imageUrl: imageUrl || undefined,
         private: isPrivate,
         ownerId: profile.id,
       });
       setSuccess("Group created!");
       setName("");
       setDescription("");
+      setImageUrl("");
       setIsPrivate(false);
     } catch {
       setError("Failed to create group");
@@ -63,6 +66,7 @@ export default function CreateGroupForm() {
           onChange={(_n, v) => setDescription(String(v))}
           rows={2}
         />
+        <PhotoUpload value={imageUrl} onChange={(url) => setImageUrl(url)} />
         <div className="flex items-center gap-2">
           <Switch
             id="private"

--- a/src/components/social/GroupCard.tsx
+++ b/src/components/social/GroupCard.tsx
@@ -11,13 +11,19 @@ export default function GroupCard({ group }: Props) {
   return (
     <Card className="p-4 flex flex-col gap-2">
       <div className="flex justify-between items-start">
-        <div>
-          <Link href={`/social/groups/${group.id}`} className="font-semibold text-lg hover:underline">
-            {group.name}
-          </Link>
-          {group.description && (
-            <p className="text-sm text-foreground/70 break-words">{group.description}</p>
+        <div className="flex items-start gap-2">
+          {group.imageUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={group.imageUrl} alt={group.name} className="w-10 h-10 object-cover rounded-md" />
           )}
+          <div>
+            <Link href={`/social/groups/${group.id}`} className="font-semibold text-lg hover:underline">
+              {group.name}
+            </Link>
+            {group.description && (
+              <p className="text-sm text-foreground/70 break-words">{group.description}</p>
+            )}
+          </div>
         </div>
         <div className="flex flex-col items-end text-sm text-foreground/60 gap-1">
           <span>{group.memberCount ?? 0} members</span>

--- a/src/lib/api/__tests__/social.test.ts
+++ b/src/lib/api/__tests__/social.test.ts
@@ -141,10 +141,11 @@ describe("social api helpers", () => {
 
   it("createGroup posts data", async () => {
     mockedAxios.post.mockResolvedValue({ data: { id: "g1" } });
-    const result = await createGroup({ name: "Test", ownerId: "p1" });
+    const result = await createGroup({ name: "Test", ownerId: "p1", imageUrl: "img" });
     expect(mockedAxios.post).toHaveBeenCalledWith("/api/social/groups", {
       name: "Test",
       ownerId: "p1",
+      imageUrl: "img",
     });
     expect(result).toEqual({ id: "g1" });
   });

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -65,6 +65,7 @@ export interface RunGroup {
   id: string;
   name: string;
   description?: string | null;
+  imageUrl?: string | null;
   private: boolean;
   ownerId: string;
   createdAt: Date;


### PR DESCRIPTION
## Summary
- allow RunGroup to store an image URL
- let users upload a photo when creating a group
- display the image on group cards and group pages
- update unit test for `createGroup`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850d292d3cc832499a77cb3ffbfc4f2