### PR TITLE
Fix tailwind opacity usage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,7 +61,8 @@ p {
     @apply border
            text-muted-foreground
            rounded-md
-           bg-accent-2/10
+          bg-accent-2
+          opacity-10
            px-3 py-2
            text-foreground
            placeholder:text-gray-500    /* ← use a default gray */
@@ -76,7 +77,7 @@ p {
 }
 
 button {
-  @apply bg-primary text-foreground px-4 py-2 rounded hover:bg-primary/80
+  @apply bg-primary text-foreground px-4 py-2 rounded hover:bg-primary hover:opacity-80
          transition-colors focus:outline-none focus:ring-2 focus:ring-secondary;
 }
 button.avatar-btn {

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -80,10 +80,10 @@ export default function GroupPage() {
           )}
         </div>
         {group.description && (
-          <p className="text-foreground/70">{group.description}</p>
+          <p className="text-foreground opacity-70">{group.description}</p>
         )}
         <Card className="p-4 space-y-2">
-          <p className="text-sm text-foreground/60">
+          <p className="text-sm text-foreground opacity-60">
             Created {new Date(group.createdAt).toLocaleDateString()}
           </p>
           <p className="text-sm">Members: {group.memberCount}</p>

--- a/src/components/social/GroupCard.tsx
+++ b/src/components/social/GroupCard.tsx
@@ -16,10 +16,10 @@ export default function GroupCard({ group }: Props) {
             {group.name}
           </Link>
           {group.description && (
-            <p className="text-sm text-foreground/70 break-words">{group.description}</p>
+            <p className="text-sm text-foreground opacity-70 break-words">{group.description}</p>
           )}
         </div>
-        <div className="flex flex-col items-end text-sm text-foreground/60 gap-1">
+        <div className="flex flex-col items-end text-sm text-foreground opacity-60 gap-1">
           <span>{group.memberCount ?? 0} members</span>
           {group.private && <Badge variant="secondary">Private</Badge>}
         </div>


### PR DESCRIPTION
## Summary
- adjust globals to use opacity utility classes
- update group pages to use opacity utilities for text

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850d974fa00832490691618f95e81b7