### PR TITLE
Add lock toggle for group privacy

### DIFF
--- a/src/components/social/CreateGroupForm.tsx
+++ b/src/components/social/CreateGroupForm.tsx
@@ -3,7 +3,7 @@ import { useState, FormEvent } from "react";
 import { useSession } from "next-auth/react";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import { createGroup } from "@lib/api/social";
-import { Card, Button, Switch, PhotoUpload } from "@components/ui";
+import { Card, Button, PhotoUpload, LockToggle, toast } from "@components/ui";
 import { TextField, TextAreaField } from "@components/ui/FormField";
 
 export default function CreateGroupForm() {
@@ -68,14 +68,14 @@ export default function CreateGroupForm() {
         />
         <PhotoUpload value={imageUrl} onChange={(url) => setImageUrl(url)} />
         <div className="flex items-center gap-2">
-          <Switch
-            id="private"
-            checked={isPrivate}
-            onCheckedChange={(v) => setIsPrivate(v)}
+          <LockToggle
+            locked={isPrivate}
+            onChange={(v) => {
+              setIsPrivate(v);
+              toast(v ? "group is private" : "group is public");
+            }}
           />
-          <label htmlFor="private" className="text-sm">
-            Private group
-          </label>
+          <span className="text-sm">{isPrivate ? "Private group" : "Public group"}</span>
         </div>
         <div className="flex justify-end">
           <Button type="submit">Create Group</Button>

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -20,6 +20,7 @@ export * from './toast';
 export * from './progress';
 export * from './skeleton';
 export * from './switch';
+export { default as LockToggle } from './lock-toggle';
 export * from './checkbox';
 export * from './radio-group';
 export * from './slider';

--- a/src/components/ui/lock-toggle.tsx
+++ b/src/components/ui/lock-toggle.tsx
@@ -1,0 +1,23 @@
+import { Lock, Unlock } from "lucide-react";
+import { Button } from "./button";
+
+interface LockToggleProps {
+  locked: boolean;
+  onChange?: (locked: boolean) => void;
+  className?: string;
+}
+
+export default function LockToggle({ locked, onChange, className }: LockToggleProps) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className={className}
+      aria-label={locked ? "group is private" : "group is public"}
+      onClick={() => onChange?.(!locked)}
+    >
+      {locked ? <Lock className="h-5 w-5" /> : <Unlock className="h-5 w-5" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- show lock icon toggle for group privacy state
- toast notification indicates whether a group is private or public
- export new `LockToggle` component via UI index

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850e064a3c08324aeffe1ce5ad42bec