### PR TITLE
Improve select field contrast

### DIFF
--- a/src/components/profile/VDOTEstimator.tsx
+++ b/src/components/profile/VDOTEstimator.tsx
@@ -47,7 +47,7 @@ export default function VDOTEstimator({ userId, onComplete }: Props) {
           id="distance"
           value={distance}
           onChange={(e) => setDistance(e.target.value as "5k" | "10k")}
-          className="w-full border rounded px-2 py-1 focus:outline-none focus:ring focus:ring-primary"
+          className="w-full h-10 rounded-md border border-accent-2 bg-accent-2 opacity-80 px-2 py-1 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
         >
           <option value="5k">5K</option>
           <option value="10k">10K</option>

--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -240,7 +240,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
               id="raceType"
               value={raceType}
               onChange={(e) => setRaceType(e.target.value as RaceType)}
-              className="border p-2 rounded bg-background text-foreground"
+              className="h-10 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-2 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
             >
               <option value="5k">5K</option>
               <option value="10k">10K</option>
@@ -262,7 +262,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
               onChange={(e) =>
                 setTrainingLevel(e.target.value as TrainingLevel)
               }
-              className="border p-2 rounded bg-background text-foreground"
+              className="h-10 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-2 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
             >
               <option value="beginner">Beginner</option>
               <option value="intermediate">Intermediate</option>
@@ -328,7 +328,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
                           e.target.value as DayOfWeek | ""
                         )
                       }
-                      className="border p-1 rounded bg-background text-foreground"
+                      className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
                     >
                       <option value="">--</option>
                       {days.map((d) => (

--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -233,7 +233,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                               e.target.value
                             )
                           }
-                          className="border p-1 rounded text-foreground"
+                          className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
                         >
                           {runTypes.map((t) => (
                             <option key={t} value={t}>
@@ -286,7 +286,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                               e.target.value as DayOfWeek
                             )
                           }
-                          className="border p-1 rounded text-foreground"
+                          className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
                         >
                           {days.map((d) => (
                             <option key={d} value={d}>
@@ -413,7 +413,7 @@ const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange })
       <select
         value={type}
         onChange={(e) => setType(e.target.value as PlannedRun["type"])}
-        className="border p-1 rounded text-foreground text-center"
+        className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-center text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
       >
         {runTypes.map((t) => (
           <option key={t} value={t}>
@@ -425,7 +425,7 @@ const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange })
       <select
         value={day}
         onChange={(e) => setDay(e.target.value as DayOfWeek)}
-        className="border p-1 rounded text-foreground text-center"
+        className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-center text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
       >
         {days.map((d) => (
           <option key={d} value={d}>

--- a/src/components/ui/FormField/SelectField.tsx
+++ b/src/components/ui/FormField/SelectField.tsx
@@ -36,7 +36,7 @@ const SelectField: React.FC<SelectFieldProps> = ({
           name={name}
           value={value}
           onChange={(e) => onChange(name, e.target.value)}
-          className="mt-1 w-full border rounded px-2 py-1 focus:outline-none focus:ring focus:ring-primary"
+          className="mt-1 h-10 w-full rounded-md border border-accent-2 bg-accent-2 opacity-80 px-2 py-1 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
           {...selectProps}
         >
           <option value="" disabled>


### PR DESCRIPTION
## Summary
- use accent styling for form `select` elements
- tweak selects in plan display for better visibility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850e327443c8324809e9e7ebec8cd36