### PR TITLE
Improve short distance training plan pacing

### DIFF
--- a/src/lib/utils/__tests__/shortDistancePlan.test.ts
+++ b/src/lib/utils/__tests__/shortDistancePlan.test.ts
@@ -3,7 +3,7 @@ import { generateShortDistancePlan, TrainingLevel } from "../running/plans/short
 describe("generateShortDistancePlan", () => {
   it("sets final run as race", () => {
     const weeks = 6;
-    const plan = generateShortDistancePlan(weeks, 6.2, "miles", TrainingLevel.Beginner, 40);
+    const plan = generateShortDistancePlan(weeks, 6.2, "miles", TrainingLevel.Beginner, 40, undefined, undefined);
     const lastWeek = plan.schedule[weeks - 1];
     expect(lastWeek.runs).toHaveLength(1);
     const lastRun = lastWeek.runs[0];
@@ -12,7 +12,7 @@ describe("generateShortDistancePlan", () => {
   });
 
   it("splits easy mileage into multiple runs", () => {
-    const plan = generateShortDistancePlan(8, 6.2, "miles", TrainingLevel.Beginner, 40);
+    const plan = generateShortDistancePlan(8, 6.2, "miles", TrainingLevel.Beginner, 40, undefined, undefined);
     plan.schedule.slice(0, -1).forEach((week) => {
       const easyRuns = week.runs.filter((r) => r.type === "easy");
       expect(easyRuns.length).toBeGreaterThan(1);
@@ -21,22 +21,22 @@ describe("generateShortDistancePlan", () => {
 
   it("labels 10k race week", () => {
     const weeks = 8;
-    const plan = generateShortDistancePlan(weeks, 10, "kilometers", TrainingLevel.Beginner, 40);
+    const plan = generateShortDistancePlan(weeks, 10, "kilometers", TrainingLevel.Beginner, 40, undefined, undefined);
     const lastWeek = plan.schedule[weeks - 1];
     expect(lastWeek.notes).toBe("10K Week!");
   });
 
   it("throws for week counts outside 4-16", () => {
     expect(() =>
-      generateShortDistancePlan(3, 6.2, "miles", TrainingLevel.Beginner, 40)
+      generateShortDistancePlan(3, 6.2, "miles", TrainingLevel.Beginner, 40, undefined, undefined)
     ).toThrow();
     expect(() =>
-      generateShortDistancePlan(17, 6.2, "miles", TrainingLevel.Beginner, 40)
+      generateShortDistancePlan(17, 6.2, "miles", TrainingLevel.Beginner, 40, undefined, undefined)
     ).toThrow();
   });
 
   it("rounds long runs to the nearest half unit", () => {
-    const plan = generateShortDistancePlan(8, 6.2, "miles", TrainingLevel.Beginner, 40);
+    const plan = generateShortDistancePlan(8, 6.2, "miles", TrainingLevel.Beginner, 40, undefined, undefined);
     plan.schedule.forEach((week) => {
       const longRun = week.runs.find((r) => r.type === "long");
       if (longRun) {

--- a/src/lib/utils/__tests__/weeklyMileageSum.test.ts
+++ b/src/lib/utils/__tests__/weeklyMileageSum.test.ts
@@ -12,7 +12,7 @@ describe("weeklyMileage totals", () => {
   });
 
   it("short plan weekly mileage equals sum of runs", () => {
-    const plan = generateShortDistancePlan(8, 6.2, "miles", ShortLevel.Beginner, 40);
+    const plan = generateShortDistancePlan(8, 6.2, "miles", ShortLevel.Beginner, 40, undefined, undefined);
     plan.schedule.forEach((week) => {
       const sum = week.runs.reduce((tot, r) => tot + r.mileage, 0);
       expect(Number(sum.toFixed(1))).toBeCloseTo(week.weeklyMileage, 1);

--- a/src/lib/utils/running/plans/distancePlans.ts
+++ b/src/lib/utils/running/plans/distancePlans.ts
@@ -30,6 +30,8 @@ export function generate5kPlan(options: DistancePlanOptions): RunningPlanData {
     distanceUnit,
     trainingLevel,
     vdot,
+    options.targetPace,
+    options.targetTotalTime,
   );
   return options.runsPerWeek
     ? customizePlanRuns(plan, {
@@ -48,6 +50,8 @@ export function generate10kPlan(options: DistancePlanOptions): RunningPlanData {
     distanceUnit,
     trainingLevel,
     vdot,
+    options.targetPace,
+    options.targetTotalTime,
   );
   return options.runsPerWeek
     ? customizePlanRuns(plan, {

--- a/src/lib/utils/running/plans/longDistancePlan.ts
+++ b/src/lib/utils/running/plans/longDistancePlan.ts
@@ -2,6 +2,7 @@ import { calculatePaceForVDOT } from "../jackDaniels";
 import { WeekPlan, RunningPlanData, PlannedRun } from "@maratypes/runningPlan";
 import { DayOfWeek } from "@maratypes/basics";
 import { formatPace } from "@utils/running/paces";
+import { parseDuration } from "@utils/time";
 
 // const formatPace = (sec: number): string => {
 //   const m = Math.floor(sec / 60);
@@ -155,21 +156,14 @@ export function generateLongDistancePlan(
   }
 
   // -- helpers
-  const parseHMS = (s: string): number => {
-    const parts = s.split(":").map(Number);
-    return parts.length === 3
-      ? parts[0] * 3600 + parts[1] * 60 + parts[2]
-      : parts[0] * 60 + parts[1];
-  };
-
   const roundToHalf = (n: number): number => Math.round(n * 2) / 2;
 
   // -- compute goal pace override
   let goalPaceSec: number | undefined;
   if (targetTotalTime) {
-    goalPaceSec = parseHMS(targetTotalTime) / targetDistance;
+    goalPaceSec = parseDuration(targetTotalTime) / targetDistance;
   } else if (targetPace) {
-    goalPaceSec = parseHMS(targetPace);
+    goalPaceSec = parseDuration(targetPace);
   }
 
   // -- distance conversions
@@ -186,9 +180,9 @@ export function generateLongDistancePlan(
   if (goalPaceSec !== undefined) zones.marathon = formatPace(goalPaceSec);
 
   // -- edge-case validation for tempo pace
-  const easySec = parseHMS(zones.easy);
-  let tempoSecNum = parseHMS(zones.tempo);
-  const marathonSec = parseHMS(zones.marathon);
+  const easySec = parseDuration(zones.easy);
+  let tempoSecNum = parseDuration(zones.tempo);
+  const marathonSec = parseDuration(zones.marathon);
   if (tempoSecNum >= easySec) {
     tempoSecNum = easySec * 0.95; // Adjust tempo pace to be generically faster than easy pace
     // throw new Error(
@@ -265,7 +259,7 @@ export function generateLongDistancePlan(
     const intervalMileage = roundToHalf(
       (workout.reps * workout.distanceMeters) / toMeters
     );
-    const baseIntervalPaceSec = parseHMS(zones.interval);
+    const baseIntervalPaceSec = parseDuration(zones.interval);
     const repDistanceUnits = workout.distanceMeters / toMeters;
     const repPaceSec = baseIntervalPaceSec * repDistanceUnits;
     const repPace = formatPace(repPaceSec);


### PR DESCRIPTION
## Summary
- reuse parseDuration helper to avoid duplicate code
- cap tempo and interval runs to race distance
- ensure training pace overrides use parseDuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850f1ad9b548324a15c7477f7b2536f