### PR TITLE
Fix duplicate variable definitions in group routes

### DIFF
--- a/src/app/api/social/groups/route.ts
+++ b/src/app/api/social/groups/route.ts
@@ -45,18 +45,18 @@ export async function POST(req: NextRequest) {
     );
   }
   try {
-    const { password, ...rest } = data;
+    const { password, ...groupInput } = data;
     const hashed = password ? await bcrypt.hash(String(password), 10) : undefined;
     const group = await prisma.runGroup.create({
-      data: { ...rest, password: hashed },
+      data: { ...groupInput, password: hashed },
     });
     // add creator as member
     await prisma.runGroupMember.create({
       data: { groupId: group.id, socialProfileId: group.ownerId },
     });
-    const { password: _password, ...rest } = group;
+    const { password: _password, ...groupWithoutPassword } = group;
     void _password;
-    return NextResponse.json(rest, { status: 201 });
+    return NextResponse.json(groupWithoutPassword, { status: 201 });
   } catch (err) {
     console.error("Error creating group", err);
     return NextResponse.json({ error: "Failed" }, { status: 500 });


### PR DESCRIPTION
## Summary
- fix duplicate `rest` variable names in `POST` route for groups

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850f6af4a60832489fd9ca3c90a3415