### PR TITLE
Improve group join/create UX

### DIFF
--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useSocialProfile } from "@hooks/useSocialProfile";
 import axios from "axios";
 import SocialFeed from "@components/social/SocialFeed";
 import GroupMembers from "@components/social/GroupMembers";
-import { Button, Spinner, Card } from "@components/ui";
+import { Button, Spinner, Card, toast } from "@components/ui";
 import type { RunGroup } from "@maratypes/social";
 
 export default function GroupPage() {
@@ -49,11 +49,19 @@ export default function GroupPage() {
       password = window.prompt("Group password") || undefined;
       if (password === undefined) return;
     }
-    await axios.post(`/api/social/groups/${id}/join`, {
-      profileId: profile.id,
-      password,
-    });
-    fetchGroup();
+    try {
+      await axios.post(`/api/social/groups/${id}/join`, {
+        profileId: profile.id,
+        password,
+      });
+      fetchGroup();
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && err.response?.status === 403) {
+        toast.error("Invalid password");
+      } else {
+        toast.error("Failed to join group");
+      }
+    }
   };
 
   const handleLeave = async () => {

--- a/src/components/social/CreateGroupForm.tsx
+++ b/src/components/social/CreateGroupForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, FormEvent } from "react";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import { useSocialProfile } from "@hooks/useSocialProfile";
 import { createGroup } from "@lib/api/social";
 import { Card, Button, PhotoUpload, LockToggle, toast } from "@components/ui";
@@ -8,6 +9,7 @@ import { TextField, TextAreaField } from "@components/ui/FormField";
 
 export default function CreateGroupForm() {
   const { data: session } = useSession();
+  const router = useRouter();
   const { profile } = useSocialProfile();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -15,12 +17,10 @@ export default function CreateGroupForm() {
   const [isPrivate, setIsPrivate] = useState(false);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
-    setSuccess("");
     if (!session?.user?.id) {
       setError("Login required");
       return;
@@ -30,7 +30,7 @@ export default function CreateGroupForm() {
       return;
     }
     try {
-      await createGroup({
+      const group = await createGroup({
         name,
         description: description || undefined,
         imageUrl: imageUrl || undefined,
@@ -38,12 +38,7 @@ export default function CreateGroupForm() {
         password: isPrivate ? password : undefined,
         ownerId: profile.id,
       });
-      setSuccess("Group created!");
-      setName("");
-      setDescription("");
-      setImageUrl("");
-      setIsPrivate(false);
-      setPassword("");
+      router.push(`/social/groups/${group.id}`);
     } catch {
       setError("Failed to create group");
     }
@@ -53,7 +48,6 @@ export default function CreateGroupForm() {
     <Card className="p-6 w-full max-w-md">
       <h2 className="text-2xl font-semibold mb-4">Create Run Group</h2>
       {error && <p className="text-brand-orange-dark mb-2">{error}</p>}
-      {success && <p className="text-primary mb-2">{success}</p>}
       <form onSubmit={handleSubmit} className="space-y-4">
         <TextField
           label="Name"


### PR DESCRIPTION
## Summary
- show toast when entering an invalid group password
- redirect user to new group page after group creation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68519afc4a38832494969eeab84d606c