### PR TITLE
Move plan edit buttons into RunningPlanDisplay

### DIFF
--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -7,7 +7,7 @@ import { getRunningPlan, updateRunningPlan } from "@lib/api/plan";
 import { assignDatesToPlan } from "@utils/running/planDates";
 import type { RunningPlan } from "@maratypes/runningPlan";
 import RunningPlanDisplay from "@components/training/RunningPlanDisplay";
-import { Button, Spinner } from "@components/ui";
+import { Spinner } from "@components/ui";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -18,7 +18,6 @@ export default function PlanPage({ params }: PageProps) {
   const { data: session, status } = useSession();
   const [plan, setPlan] = useState<RunningPlan | null>(null);
   const [planData, setPlanData] = useState<RunningPlan["planData"] | null>(null);
-  const [editing, setEditing] = useState(false);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
@@ -65,40 +64,26 @@ export default function PlanPage({ params }: PageProps) {
     );
   }
 
+  const handleSave = async (updated: RunningPlan["planData"]) => {
+    if (!plan?.id) return;
+    try {
+      await updateRunningPlan(plan.id, { planData: updated });
+      setPlan((p) => (p ? { ...p, planData: updated } : p));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <main className="w-full px-4 sm:px-6 lg:px-8 py-4 space-y-4">
       <h1 className="text-2xl font-bold mb-4">{plan.name}</h1>
-      <div className="mb-4 space-x-2">
-        <Button
-          onClick={() => setEditing((e) => !e)}
-          className="block w-auto border-none focus:outline-none focus:ring-0 text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
-        >
-          {editing ? "Cancel" : "Edit"}
-        </Button>
-        {editing && (
-          <Button
-            onClick={async () => {
-              if (!plan.id || !planData) return;
-              try {
-                await updateRunningPlan(plan.id, { planData });
-                setEditing(false);
-                setPlan((p) => (p ? { ...p, planData } : p));
-              } catch (err) {
-                console.error(err);
-              }
-            }}
-            className="block w-auto border-none focus:outline-none focus:ring-0 text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
-          >
-            Save
-          </Button>
-        )}
-      </div>
       {planData && (
         <RunningPlanDisplay
           planData={planData}
           planName={plan.name}
-          editable={editing}
+          allowEditable
           onPlanChange={setPlanData}
+          onSave={handleSave}
         />
       )}
     </main>

--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -7,11 +7,20 @@ import { RunningPlanData, WeekPlan, PlannedRun } from "@maratypes/runningPlan";
 import { DayOfWeek } from "@maratypes/basics";
 import { setDayForRunType } from "@utils/running/setRunDay";
 import { parsePace, formatPace } from "@utils/running/paces";
+import { Button } from "@components/ui";
 
 interface RunningPlanDisplayProps {
   planData: RunningPlanData;
   planName?: string;
+  /**
+   * Set the initial editable state of the plan schedule.
+   */
   editable?: boolean;
+  /**
+   * Allows the user to toggle edit mode and save changes. Used when
+   * displaying an existing plan.
+   */
+  allowEditable?: boolean;
   /**
    * Show controls for editing the plan name and saving the plan.
    */
@@ -22,16 +31,23 @@ interface RunningPlanDisplayProps {
   showBulkDaySetter?: boolean;
   onPlanChange?: (plan: RunningPlanData) => void;
   onPlanNameChange?: (name: string) => void;
+  /**
+   * Callback invoked when the Save button is clicked while editing an
+   * existing plan. The updated plan data is provided.
+   */
+  onSave?: (planData: RunningPlanData) => Promise<void> | void;
 }
 
 const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
   planData,
   planName,
   editable = false,
+  allowEditable = false,
   showPlanMeta = false,
   showBulkDaySetter = false,
   onPlanChange,
   onPlanNameChange,
+  onSave,
 }) => {
   const { profile: user } = useUser();
   const [editingName, setEditingName] = useState(false);
@@ -131,9 +147,32 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
           </div>
         </>
       ) : (
-        <h2 className="text-2xl font-bold text-center mb-4">
-          {planName || "Your Running Plan"}
-        </h2>
+        <>
+          <h2 className="text-2xl font-bold text-center mb-2">
+            {planName || "Your Running Plan"}
+          </h2>
+          {allowEditable && (
+            <div className="mb-4 flex justify-center gap-2">
+              <Button
+                onClick={() => setIsEditable((e) => !e)}
+                className="border-none bg-transparent text-foreground hover:bg-brand-from hover:text-background"
+              >
+                {isEditable ? "Cancel" : "Edit"}
+              </Button>
+              {isEditable && (
+                <Button
+                  onClick={async () => {
+                    await onSave?.(planData);
+                    setIsEditable(false);
+                  }}
+                  className="border-none bg-transparent text-foreground hover:bg-brand-from hover:text-background"
+                >
+                  Save
+                </Button>
+              )}
+            </div>
+          )}
+        </>
       )}
       {(isEditable || showBulkDaySetter) && (
         <BulkDaySetter planData={planData} onPlanChange={onPlanChange} />


### PR DESCRIPTION
## Summary
- add `allowEditable` and `onSave` props to `RunningPlanDisplay`
- show Edit/Save buttons inside `RunningPlanDisplay`
- update plan page to use new props and remove local edit UI

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851bae3224883249168bf044a845ea9