### PR TITLE
refactor: use custom form components

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,8 @@ import React, { useState, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { signIn, useSession } from "next-auth/react";
 import { Spinner } from "@components/ui";
+import { Input } from "@components/ui/input";
+import { Button } from "@components/ui/button";
 
 const LoginPage: React.FC = () => {
   const { data: session, status } = useSession();
@@ -65,12 +67,12 @@ const LoginPage: React.FC = () => {
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <h1 className="text-3xl font-bold text-center">You are logged in!</h1>
         <div className="flex justify-center">
-          <button
+          <Button
             onClick={() => router.push("/home")}
-            className="bg-primary text-foreground px-4 py-2 rounded-md hover:bg-primary hover:opacity-80 transition-colors"
+            className="bg-primary px-4 py-2 rounded-md hover:bg-primary hover:opacity-80 block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
           >
             Go Home
-          </button>
+          </Button>
         </div>
       </main>
     );
@@ -83,13 +85,13 @@ const LoginPage: React.FC = () => {
         <h1 className="text-3xl font-bold text-center">Login</h1>
         {error && <p className="text-brand-orange-dark text-center">{error}</p>}
         <div className="flex justify-center">
-          <button
+          <Button
             type="button"
             onClick={jacksonLogin}
-            className="border px-4 py-2 rounded-md hover:bg-accent hover:opacity-20 transition"
+            className="border px-4 py-2 rounded-md hover:bg-accent hover:opacity-20 transition block w-auto text-foreground bg-transparent no-underline hover:text-background hover:no-underline hover:bg-brand-from"
           >
             Jackson login
-          </button>
+          </Button>
         </div>
         <form
           onSubmit={handleLogin}
@@ -99,7 +101,7 @@ const LoginPage: React.FC = () => {
             <label htmlFor="email" className="block text-foreground mb-2">
               Email:
             </label>
-            <input
+            <Input
               id="email"
               type="email"
               value={email}
@@ -112,7 +114,7 @@ const LoginPage: React.FC = () => {
             <label htmlFor="password" className="block text-foreground mb-2">
               Password:
             </label>
-            <input
+            <Input
               id="password"
               type="password"
               value={password}
@@ -121,22 +123,22 @@ const LoginPage: React.FC = () => {
               className="w-full px-3 py-2 border rounded focus:outline-none focus:ring"
             />
           </div>
-          <button
+          <Button
             type="submit"
             className="block mx-auto w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
           >
             Login
-          </button>
+          </Button>
           <div className="text-center my-4">
             <span className="text-foreground opacity-50">or</span>
           </div>
-          <button
+          <Button
             type="button"
             onClick={() => router.push("/signup")}
             className="block mx-auto w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
           >
             Not registered? Sign up
-          </button>
+          </Button>
         </form>
       </main>
     </div>

--- a/src/components/AuthTest.tsx
+++ b/src/components/AuthTest.tsx
@@ -3,6 +3,8 @@
 import React, { useState, FormEvent } from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Spinner } from "@components/ui";
+import { Input } from "@components/ui/input";
+import { Button } from "@components/ui/button";
 
 const AuthTest: React.FC = () => {
   const { data: session, status } = useSession();
@@ -42,7 +44,12 @@ const AuthTest: React.FC = () => {
         <>
           <h2>Welcome, {session.user.name || session.user.email}!</h2>
           <p>Email: {session.user.email}</p>
-          <button onClick={handleLogout}>Logout</button>
+          <Button
+            onClick={handleLogout}
+            className="block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
+          >
+            Logout
+          </Button>
         </>
       ) : (
         <>
@@ -51,7 +58,7 @@ const AuthTest: React.FC = () => {
           <form onSubmit={handleLogin}>
             <div>
               <label>Email:</label>
-              <input
+              <Input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -60,16 +67,20 @@ const AuthTest: React.FC = () => {
             </div>
             <div style={{ marginTop: "0.5rem" }}>
               <label>Password:</label>
-              <input
+              <Input
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
               />
             </div>
-            <button type="submit" style={{ marginTop: "1rem" }}>
+            <Button
+              type="submit"
+              style={{ marginTop: "1rem" }}
+              className="block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
+            >
               Login
-            </button>
+            </Button>
           </form>
         </>
       )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { usePathname } from "next/navigation";
 import { Menu } from "lucide-react";
 import DefaultAvatar from "@components/DefaultAvatar";
 import { Sheet, SheetContent, SheetTrigger } from "@components/ui";
+import { Button } from "@components/ui/button";
 // import ModeToggle from "@components/ModeToggle";
 
 export default function Navbar() {
@@ -114,11 +115,11 @@ export default function Navbar() {
             <>
               {/* User Avatar + Dropdown */}
               <div className="relative">
-                <button
+                <Button
                   onClick={() => setDesktopMenuOpen((o) => !o)}
                   aria-label="Toggle user menu"
                   aria-expanded={desktopMenuOpen}
-                  className="focus:outline-none bg-transparent p-0 hover:bg-transparent focus:ring-0"
+                  className="focus:outline-none bg-transparent p-0 hover:bg-transparent focus:ring-0 block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
                 >
                   {session.user?.avatarUrl ? (
                     <Image
@@ -135,7 +136,7 @@ export default function Navbar() {
                       className="border border-brand-to bg-brand-from"
                     />
                   )}
-                </button>
+                </Button>
                 {desktopMenuOpen && (
                   <div className="absolute right-0 mt-2 w-40 bg-background border border-accent rounded shadow-md z-50 flex flex-col items-center">
                     <Link
@@ -150,23 +151,23 @@ export default function Navbar() {
                     >
                       Settings
                     </Link>
-                    <button
+                    <Button
                       onClick={() => signOut()}
                       className="block w-full text-center py-2 bg-transparent justify-center text-foreground no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
                     >
                       Logout
-                    </button>
+                    </Button>
                   </div>
                 )}
               </div>
             </>
           ) : (
-            <button
+            <Button
               onClick={() => signIn()}
-              className="text-foreground no-underline transition-colors bg-transparent hover:text-background hover:no-underline hover:bg-brand-from"
+              className="text-foreground no-underline transition-colors bg-transparent hover:text-background hover:no-underline hover:bg-brand-from block w-auto"
             >
               Sign In
-            </button>
+            </Button>
           )}
           {/* <ModeToggle /> */}
         </div>
@@ -175,11 +176,11 @@ export default function Navbar() {
         <div className="md:hidden flex items-center">
           {/* Avatar (mobile) */}
           {status !== "loading" && session?.user && (
-            <button
+            <Button
               onClick={() => setDesktopMenuOpen((o) => !o)}
               aria-label="Toggle user menu"
               aria-expanded={desktopMenuOpen}
-              className="focus:outline-none bg-transparent p-4 hover:bg-transparent focus:ring-0"
+              className="focus:outline-none bg-transparent p-4 hover:bg-transparent focus:ring-0 block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
             >
               {session.user?.avatarUrl ? (
                 <Image
@@ -196,18 +197,18 @@ export default function Navbar() {
                   className="border border-brand-to bg-brand-from"
                 />
               )}
-            </button>
+            </Button>
           )}
 
           {/* Hamburger icon (mobile) */}
           <Sheet>
             <SheetTrigger asChild>
-              <button
+              <Button
                 aria-label="Toggle mobile menu"
-                className="p-2 focus:outline-none bg-transparent hover:bg-transparent focus:ring-0 hover:text-primary transition-colors"
+                className="p-2 focus:outline-none bg-transparent hover:bg-transparent focus:ring-0 hover:text-primary transition-colors block w-auto text-foreground bg-transparent no-underline hover:text-background hover:no-underline hover:bg-brand-from"
               >
                 <Menu className="w-6 h-6" />
-              </button>
+              </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-6 space-y-4 w-1/2">
               {status !== "loading" && session?.user ? (
@@ -243,20 +244,20 @@ export default function Navbar() {
                   >
                     Settings
                   </Link>
-                  <button
+                  <Button
                     onClick={() => signOut()}
                     className="block mx-auto w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from border-none"
                   >
                     Logout
-                  </button>
+                  </Button>
                 </>
               ) : (
-                <button
+                <Button
                   onClick={() => signIn()}
-                  className="text-foreground no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
+                  className="text-foreground no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from block w-auto"
                 >
                   Sign In
-                </button>
+                </Button>
               )}
               {/* <ModeToggle /> */}
             </SheetContent>

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { Input } from "@components/ui/input";
 
 interface ToggleSwitchProps {
   checked?: boolean;
@@ -17,7 +18,7 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
 }) => {
   return (
     <label className="toggle-container">
-      <input
+      <Input
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange?.(e.target.checked)}

--- a/src/components/profile/VDOTEstimator.tsx
+++ b/src/components/profile/VDOTEstimator.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Button, Input, Label } from "@components/ui";
+import { SelectField } from "@components/ui/FormField";
 import { calculateVDOTJackDaniels } from "@utils/running/jackDaniels";
 import { parseDuration } from "@utils/time";
 import { updateUser } from "@lib/api/user/user";
@@ -43,15 +44,17 @@ export default function VDOTEstimator({ userId, onComplete }: Props) {
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-1">
         <Label htmlFor="distance">Race Distance</Label>
-        <select
-          id="distance"
+        <SelectField
+          name="distance"
+          label=""
           value={distance}
-          onChange={(e) => setDistance(e.target.value as "5k" | "10k")}
+          onChange={(_, value) => setDistance(value as "5k" | "10k")}
+          options={[
+            { value: "5k", label: "5K" },
+            { value: "10k", label: "10K" },
+          ]}
           className="w-full h-10 rounded-md border border-accent-2 bg-accent-2 opacity-80 px-2 py-1 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-        >
-          <option value="5k">5K</option>
-          <option value="10k">10K</option>
-        </select>
+        />
       </div>
       <div className="space-y-1">
         <Label htmlFor="time">Race Time (mm:ss or hh:mm:ss)</Label>

--- a/src/components/runs/RunModal.tsx
+++ b/src/components/runs/RunModal.tsx
@@ -2,6 +2,7 @@
 
 import { Run } from "@maratypes/run";
 import { Card } from "@components/ui";
+import { Button } from "@components/ui/button";
 import { getRunName } from "@utils/running/getRunName";
 
 interface RunModalProps {
@@ -15,21 +16,13 @@ export default function RunModal({ run, onClose }: RunModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground opacity-50">
       <Card className="relative w-1/2 bg-background p-6 rounded-lg shadow-lg">
-        <button
+        <Button
           aria-label="Close"
           onClick={onClose}
-          className="
-            absolute
-            top-2 right-2
-            bg-transparent
-            text-2xl font-bold
-            text-foreground opacity-60 dark:text-foreground dark:opacity-60
-            hover:text-foreground
-            focus:outline-none
-          "
+          className="absolute top-2 right-2 bg-transparent text-2xl font-bold text-foreground opacity-60 dark:text-foreground dark:opacity-60 hover:text-foreground focus:outline-none block w-auto no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
         >
           ×
-        </button>
+        </Button>
 
         <h2 className="text-lg font-semibold mb-4 text-foreground">
           {run.name || getRunName(run)}

--- a/src/components/shoes/ShoeForm.tsx
+++ b/src/components/shoes/ShoeForm.tsx
@@ -8,6 +8,7 @@ import { useSession } from "next-auth/react";
 import { useUser } from "@hooks/useUser";
 
 import { Card, Button, Spinner } from "@components/ui";
+import { Input } from "@components/ui/input";
 import {
   TextField,
   SelectField,
@@ -184,7 +185,7 @@ const ShoeForm: React.FC<ShoeFormProps> = ({ onSubmit, initialData }) => {
         </div>
 
         <label className="flex items-center space-x-2">
-          <input
+          <Input
             type="checkbox"
             name="makeDefault"
             checked={form.makeDefault}

--- a/src/components/training/PaceCalculator.tsx
+++ b/src/components/training/PaceCalculator.tsx
@@ -6,6 +6,8 @@ import {
   RacePrediction,
   calculateRacePaces,
 } from "@lib/utils/running/calculateRacePaces";
+import { Input } from "@components/ui/input";
+import { Button } from "@components/ui/button";
 
 const PaceCalculator: React.FC = () => {
   const [raceTime, setRaceTime] = useState(""); // Known race time in minutes
@@ -34,20 +36,25 @@ const PaceCalculator: React.FC = () => {
     <div>
       <h2>Race Pace Calculator</h2>
       <label>Known Race Time (minutes):</label>
-      <input
+      <Input
         type="number"
         value={raceTime}
         onChange={(e) => setRaceTime(e.target.value)}
       />
 
       <label>Known Race Distance (km):</label>
-      <input
+      <Input
         type="number"
         value={distance}
         onChange={(e) => setDistance(e.target.value)}
       />
 
-      <button onClick={handleCalculate}>Calculate Predictions</button>
+      <Button
+        onClick={handleCalculate}
+        className="block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
+      >
+        Calculate Predictions
+      </Button>
 
       {predictions.length > 0 && (
         <div>

--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -6,6 +6,9 @@ import type { DayOfWeek } from "@maratypes/basics";
 import type { PlannedRun } from "@maratypes/runningPlan";
 import ToggleSwitch from "@components/ToggleSwitch";
 import { Spinner } from "@components/ui";
+import { Input } from "@components/ui/input";
+import { SelectField } from "@components/ui/FormField";
+import { Button } from "@components/ui/button";
 import RunningPlanDisplay from "./RunningPlanDisplay";
 import {
   generate5kPlan,
@@ -209,7 +212,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
             <label htmlFor="weeks" className="mb-1">
               Weeks:
             </label>
-            <input
+            <Input
               id="weeks"
               type="number"
               min={8}
@@ -223,7 +226,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
             <label htmlFor="raceDate" className="mb-1">
               Race Date:
             </label>
-            <input
+            <Input
               id="raceDate"
               type="date"
               value={endDate}
@@ -236,17 +239,19 @@ const [targetDistance, setTargetDistance] = useState<number>(
             <label htmlFor="raceType" className="mb-1">
               Race Distance:
             </label>
-            <select
-              id="raceType"
+            <SelectField
+              label="Race Distance:"
+              name="raceType"
               value={raceType}
-              onChange={(e) => setRaceType(e.target.value as RaceType)}
+              onChange={(_, value) => setRaceType(value as RaceType)}
+              options={[
+                { value: "5k", label: "5K" },
+                { value: "10k", label: "10K" },
+                { value: "half", label: "Half Marathon" },
+                { value: "full", label: "Marathon" },
+              ]}
               className="h-10 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-2 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-            >
-              <option value="5k">5K</option>
-              <option value="10k">10K</option>
-              <option value="half">Half Marathon</option>
-              <option value="full">Marathon</option>
-            </select>
+            />
             <span className="text-sm mt-1">
               Target Distance: {targetDistance} {distanceUnit}
             </span>
@@ -256,27 +261,29 @@ const [targetDistance, setTargetDistance] = useState<number>(
             <label htmlFor="trainingLevel" className="mb-1">
               Training Level:
             </label>
-            <select
-              id="trainingLevel"
+            <SelectField
+              label="Training Level:"
+              name="trainingLevel"
               value={trainingLevel}
-              onChange={(e) =>
-                setTrainingLevel(e.target.value as TrainingLevel)
+              onChange={(_, value) =>
+                setTrainingLevel(value as TrainingLevel)
               }
+              options={[
+                { value: "beginner", label: "Beginner" },
+                { value: "intermediate", label: "Intermediate" },
+                { value: "advanced", label: "Advanced" },
+              ]}
               className="h-10 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-2 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-            >
-              <option value="beginner">Beginner</option>
-              <option value="intermediate">Intermediate</option>
-              <option value="advanced">Advanced</option>
-            </select>
+            />
           </div>
 
-          <button
+          <Button
             type="button"
             onClick={() => setShowAdvanced((p) => !p)}
-            className="text-primary underline"
+            className="text-primary underline block w-auto bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
           >
             {showAdvanced ? "Hide Advanced" : "Show Advanced"}
-          </button>
+          </Button>
 
           {showAdvanced && (
             <div className="border rounded p-4 space-y-4">
@@ -285,7 +292,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
                 <label htmlFor="runsPerWeek" className="mb-1">
                   Runs per Week:
                 </label>
-                <input
+                <Input
                   id="runsPerWeek"
                   type="number"
                   min={2}
@@ -300,7 +307,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
                 <label htmlFor="crossDays" className="mb-1">
                   Cross Training Days:
                 </label>
-                <input
+                <Input
                   id="crossDays"
                   type="number"
                   min={0}
@@ -320,23 +327,19 @@ const [targetDistance, setTargetDistance] = useState<number>(
                 {runTypes.map((t) => (
                   <label key={t} className="flex items-center gap-2">
                     <span className="capitalize w-20">{t}:</span>
-                    <select
+                    <SelectField
+                      name={t}
+                      label=""
                       value={runTypeDays[t] ?? ""}
-                      onChange={(e) =>
-                        handleRunDayChange(
-                          t,
-                          e.target.value as DayOfWeek | ""
-                        )
+                      onChange={(_, value) =>
+                        handleRunDayChange(t, value as DayOfWeek | "")
                       }
+                      options={[
+                        { value: "", label: "--" },
+                        ...days.map((d) => ({ value: d, label: d })),
+                      ]}
                       className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-                    >
-                      <option value="">--</option>
-                      {days.map((d) => (
-                        <option key={d} value={d}>
-                          {d}
-                        </option>
-                      ))}
-                    </select>
+                    />
                   </label>
                 ))}
               </div>
@@ -360,7 +363,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
               <label htmlFor="targetTotalTime" className="mb-1">
                 Target Total Time (hh:mm:ss or mm:ss):
               </label>
-              <input
+              <Input
                 id="targetTotalTime"
                 type="text"
                 value={targetTotalTime}
@@ -373,7 +376,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
               <label htmlFor="targetPace" className="mb-1">
                 Target Pace (mm:ss):
               </label>
-              <input
+              <Input
                 id="targetPace"
                 type="text"
                 value={targetPace}
@@ -382,12 +385,12 @@ const [targetDistance, setTargetDistance] = useState<number>(
               />
             </div>
           )}
-          <button
+          <Button
             type="submit"
-            className="w-full bg-primary text-foreground p-2 rounded hover:bg-primary hover:opacity-80"
+            className="w-full bg-primary p-2 rounded hover:bg-primary hover:opacity-80 block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
           >
             Generate Plan
-          </button>
+          </Button>
         </form>
       )}
       {planData && (
@@ -402,7 +405,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
           />
           <div className="mt-4">
             <label className="flex items-center space-x-2">
-              <input
+              <Input
                 type="checkbox"
                 checked={showJson}
                 onChange={(e) => setShowJson(e.target.checked)}
@@ -410,7 +413,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
               />
               <span>Show JSON</span>
               {showJson && (
-                <button
+                <Button
                   type="button"
                   onClick={() => {
                     navigator.clipboard.writeText(
@@ -418,10 +421,10 @@ const [targetDistance, setTargetDistance] = useState<number>(
                     );
                     alert("JSON copied to clipboard!");
                   }}
-                  className="ml-2 text-primary underline"
+                  className="ml-2 text-primary underline block w-auto bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
                 >
                   Copy JSON
-                </button>
+                </Button>
               )}
             </label>
             {showJson && (

--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -8,6 +8,8 @@ import { DayOfWeek } from "@maratypes/basics";
 import { setDayForRunType } from "@utils/running/setRunDay";
 import { parsePace, formatPace } from "@utils/running/paces";
 import { Button } from "@components/ui";
+import { Input } from "@components/ui/input";
+import { SelectField } from "@components/ui/FormField";
 
 interface RunningPlanDisplayProps {
   planData: RunningPlanData;
@@ -94,7 +96,7 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
           <div className="mb-4 flex items-center gap-2">
             {/* <span className="font-semibold">Plan Name:</span> */}
             {editingName ? (
-              <input
+              <Input
                 type="text"
                 value={planName}
                 onChange={(e) => onPlanNameChange?.(e.target.value)}
@@ -105,31 +107,31 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
             ) : (
               <h2 className="w-full text-2xl font-bold text-center mb-4">
                 {planName}
-                <button
+                <Button
                   type="button"
                   onClick={() => setEditingName(true)}
-                  className="text-foreground hover:text-primary"
+                  className="text-foreground hover:text-primary block w-auto bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
                 >
                   <Pencil className="w-4 h-4" />
-                </button>
+                </Button>
               </h2>
             )}
           </div>
           <div className="mt-4 flex justify-center gap-4 py-5">
-            <button
+            <Button
               type="button"
               onClick={handleSave}
-              className="bg-muted-foreground text-underline text-foreground px-4 py-2 rounded hover:bg-brand-to hover:text-background"
+              className="bg-muted-foreground text-underline px-4 py-2 rounded hover:bg-brand-to hover:text-background block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
             >
               Save Plan
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               onClick={() => setIsEditable((e) => !e)}
-              className="bg-muted-foreground text-underline text-foreground px-4 py-2 rounded hover:bg-brand-to hover:text-background"
+              className="bg-muted-foreground text-underline px-4 py-2 rounded hover:bg-brand-to hover:text-background block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
             >
               {isEditable ? "Done" : "Edit"}
-            </button>
+            </Button>
           </div>
           <div className="mb-4 justify-center flex gap-8">
             <div>
@@ -262,28 +264,20 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                     <div className="space-y-1">
                       <label className="block">
                         <span className="mr-2">Type:</span>
-                        <select
+                        <SelectField
+                          name="type"
+                          label=""
+                          options={runTypes.map((t) => ({ label: t, value: t }))}
                           value={run.type}
-                          onChange={(e) =>
-                            updateRun(
-                              weekIndex,
-                              index,
-                              "type",
-                              e.target.value
-                            )
+                          onChange={(_, value) =>
+                            updateRun(weekIndex, index, "type", value)
                           }
                           className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-                        >
-                          {runTypes.map((t) => (
-                            <option key={t} value={t}>
-                              {t}
-                            </option>
-                          ))}
-                        </select>
+                        />
                       </label>
                       <label className="block">
                         <span className="mr-2">Mileage:</span>
-                        <input
+                        <Input
                           type="number"
                           step="0.1"
                           value={run.mileage}
@@ -301,7 +295,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                       </label>
                       <label className="block">
                         <span className="mr-2">Target Pace:</span>
-                        <input
+                        <Input
                           type="text"
                           value={run.targetPace.pace}
                           onChange={(e) =>
@@ -315,28 +309,25 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                       </label>
                       <label className="block">
                         <span className="mr-2">Day:</span>
-                        <select
+                        <SelectField
+                          name="day"
+                          label=""
+                          options={days.map((d) => ({ label: d, value: d }))}
                           value={run.day || "Sunday"}
-                          onChange={(e) =>
+                          onChange={(_, value) =>
                             updateRun(
                               weekIndex,
                               index,
                               "day",
-                              e.target.value as DayOfWeek
+                              value as DayOfWeek
                             )
                           }
                           className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-                        >
-                          {days.map((d) => (
-                            <option key={d} value={d}>
-                              {d}
-                            </option>
-                          ))}
-                        </select>
+                        />
                       </label>
                       <label className="block">
                         <span className="mr-2">Notes:</span>
-                        <input
+                        <Input
                           type="text"
                           value={run.notes || ""}
                           onChange={(e) =>
@@ -346,7 +337,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                         />
                       </label>
                       <label className="block">
-                        <input
+                        <Input
                           type="checkbox"
                           checked={run.done || false}
                           onChange={(e) =>
@@ -392,7 +383,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                       )}
                       {typeof run.done !== "undefined" && (
                         <p>
-                          <input
+                          <Input
                             type="checkbox"
                             checked={run.done}
                             onChange={(e) =>
@@ -449,36 +440,30 @@ const BulkDaySetter: React.FC<BulkDaySetterProps> = ({ planData, onPlanChange })
   return (
     <div className="mb-4 flex items-center gap-2 justify-center">
       <span>Set all</span>
-      <select
+      <SelectField
+        name="bulkType"
+        label=""
         value={type}
-        onChange={(e) => setType(e.target.value as PlannedRun["type"])}
+        options={runTypes.map((t) => ({ label: t, value: t }))}
+        onChange={(_, value) => setType(value as PlannedRun["type"])}
         className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-center text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-      >
-        {runTypes.map((t) => (
-          <option key={t} value={t}>
-            {t}
-          </option>
-        ))}
-      </select>
+      />
       <span>runs to</span>
-      <select
+      <SelectField
+        name="bulkDay"
+        label=""
         value={day}
-        onChange={(e) => setDay(e.target.value as DayOfWeek)}
+        options={days.map((d) => ({ label: d, value: d }))}
+        onChange={(_, value) => setDay(value as DayOfWeek)}
         className="h-8 rounded-md border border-accent-2 bg-accent-2 opacity-80 p-1 text-center text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2"
-      >
-        {days.map((d) => (
-          <option key={d} value={d}>
-            {d}
-          </option>
-        ))}
-      </select>
-      <button
+      />
+      <Button
         type="button"
         onClick={apply}
-        className="bg-primary text-foreground px-3 py-1 rounded"
+        className="bg-primary px-3 py-1 rounded block w-auto text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"
       >
         Apply
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/components/ui/FormField/CheckboxGroupField.tsx
+++ b/src/components/ui/FormField/CheckboxGroupField.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Label } from "@components/ui";
+import { Input } from "@components/ui/input";
 
 export interface CheckboxGroupFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
@@ -34,7 +35,7 @@ const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
         <div className="flex flex-wrap gap-4">
           {options.map((opt) => (
             <label key={opt.value} className="inline-flex items-center">
-              <input
+              <Input
                 id={opt.value}
                 name={name}
                 type="checkbox"

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 import { Avatar, AvatarImage, AvatarFallback, Button } from "@components/ui";
+import { Input } from "@components/ui/input";
 import { uploadAvatar } from "@lib/api/user/user";
 import DefaultAvatar from "@components/DefaultAvatar";
 
@@ -42,7 +43,7 @@ export default function AvatarUpload({ value, onChange, disabled }: AvatarUpload
         >
           Upload
         </Button>
-        <input
+        <Input
           ref={inputRef}
           type="file"
           accept="image/*"

--- a/src/components/ui/photo-upload.tsx
+++ b/src/components/ui/photo-upload.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 import { Button } from "@components/ui";
+import { Input } from "@components/ui/input";
 import { uploadImage } from "@lib/api/upload";
 
 interface PhotoUploadProps {
@@ -42,7 +43,7 @@ export default function PhotoUpload({ value, onChange, disabled, text }: PhotoUp
         >
           {text || "Upload Photo"}
         </Button>
-        <input
+        <Input
           ref={inputRef}
           type="file"
           accept="image/*"


### PR DESCRIPTION
## Summary
- replace native inputs, selects, and buttons with shadcn/ui components
- update login page and various forms to use `<Input>`, `<SelectField>`, and `<Button>`
- style all buttons with hover classes
- refactor navbar, modals, and profile forms to match

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852348bd3e4832492a26c73d1ab1806