### PR TITLE
Improve Input component flexibility

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -105,7 +105,7 @@ const LoginPage: React.FC = () => {
               id="email"
               type="email"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
               required
               className="w-full px-3 py-2 border rounded focus:outline-none focus:ring"
             />
@@ -118,7 +118,7 @@ const LoginPage: React.FC = () => {
               id="password"
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
               required
               className="w-full px-3 py-2 border rounded focus:outline-none focus:ring"
             />

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -64,7 +64,7 @@ export default function SignupPage() {
                 <Input
                   id="name"
                   value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
                   placeholder="Your Name"
                 />
               </div>
@@ -74,7 +74,7 @@ export default function SignupPage() {
                   type="email"
                   id="email"
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
                   placeholder="you@example.com"
                 />
               </div>
@@ -84,7 +84,7 @@ export default function SignupPage() {
                   type="password"
                   id="password"
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
                   placeholder="Password"
                 />
               </div>

--- a/src/components/AuthTest.tsx
+++ b/src/components/AuthTest.tsx
@@ -61,7 +61,7 @@ const AuthTest: React.FC = () => {
               <Input
                 type="email"
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
                 required
               />
             </div>
@@ -70,7 +70,7 @@ const AuthTest: React.FC = () => {
               <Input
                 type="password"
                 value={password}
-                onChange={(e) => setPassword(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
                 required
               />
             </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -39,13 +39,13 @@ export default function ContactForm() {
         type="email"
         placeholder="Your email"
         value={email}
-        onChange={(e) => setEmail(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
         required
       />
       <Textarea
         placeholder="Message"
         value={message}
-        onChange={(e) => setMessage(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setMessage(e.target.value)}
         rows={3}
         required
       />

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -35,7 +35,7 @@ export default function NewsletterSignup() {
         type="email"
         placeholder="Your email"
         value={email}
-        onChange={(e) => setEmail(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
         className="max-w-xs"
         required
       />

--- a/src/components/profile/VDOTEstimator.tsx
+++ b/src/components/profile/VDOTEstimator.tsx
@@ -61,7 +61,7 @@ export default function VDOTEstimator({ userId, onComplete }: Props) {
         <Input
           id="time"
           value={time}
-          onChange={(e) => setTime(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTime(e.target.value)}
           placeholder="30:00"
         />
       </div>

--- a/src/components/shoes/ShoeForm.tsx
+++ b/src/components/shoes/ShoeForm.tsx
@@ -189,7 +189,7 @@ const ShoeForm: React.FC<ShoeFormProps> = ({ onSubmit, initialData }) => {
             type="checkbox"
             name="makeDefault"
             checked={form.makeDefault}
-            onChange={(e) =>
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               handleFieldChange("makeDefault", e.target.checked)
             }
           />

--- a/src/components/social/CommentSection.tsx
+++ b/src/components/social/CommentSection.tsx
@@ -97,7 +97,7 @@ export default function CommentSection({
             <form onSubmit={onSubmit} className="flex gap-2 mt-2">
               <Input
                 value={text}
-                onChange={(e) => setText(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setText(e.target.value)}
                 placeholder="Add a comment"
                 className="h-8"
               />

--- a/src/components/social/ProfileSearch.tsx
+++ b/src/components/social/ProfileSearch.tsx
@@ -99,7 +99,7 @@ export default function ProfileSearch({ limit }: Props) {
           placeholder="Search runners"
           className="placeholder:text-foreground"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
         />
         <Button
           type="submit"

--- a/src/components/training/PaceCalculator.tsx
+++ b/src/components/training/PaceCalculator.tsx
@@ -39,14 +39,16 @@ const PaceCalculator: React.FC = () => {
       <Input
         type="number"
         value={raceTime}
-        onChange={(e) => setRaceTime(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setRaceTime(e.target.value)
+        }
       />
 
       <label>Known Race Distance (km):</label>
       <Input
         type="number"
         value={distance}
-        onChange={(e) => setDistance(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDistance(e.target.value)}
       />
 
       <Button

--- a/src/components/training/PlanGenerator.tsx
+++ b/src/components/training/PlanGenerator.tsx
@@ -362,7 +362,7 @@ const [targetDistance, setTargetDistance] = useState<number>(
                   name="showJson"
                   type="checkbox"
                   checked={showJson}
-                  onChange={(e) => setShowJson(e.target.checked)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setShowJson(e.target.checked)}
                   className="form-checkbox"
                 />
                 <span>Show JSON</span>

--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -99,7 +99,7 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
               <Input
                 type="text"
                 value={planName}
-                onChange={(e) => onPlanNameChange?.(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => onPlanNameChange?.(e.target.value)}
                 onBlur={() => setEditingName(false)}
                 autoFocus
                 className="w-full max-w-md text-2xl font-bold text-center mb-4 block mx-auto"
@@ -281,7 +281,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                           type="number"
                           step="0.1"
                           value={run.mileage}
-                          onChange={(e) =>
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             updateRun(
                               weekIndex,
                               index,
@@ -298,7 +298,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                         <Input
                           type="text"
                           value={run.targetPace.pace}
-                          onChange={(e) =>
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             updateRun(weekIndex, index, "targetPace", {
                               ...run.targetPace,
                               pace: formatPace(parsePace(e.target.value)),
@@ -330,7 +330,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                         <Input
                           type="text"
                           value={run.notes || ""}
-                          onChange={(e) =>
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             updateRun(weekIndex, index, "notes", e.target.value)
                           }
                           className="border p-1 rounded text-foreground w-full"
@@ -340,7 +340,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                         <Input
                           type="checkbox"
                           checked={run.done || false}
-                          onChange={(e) =>
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             updateRun(
                               weekIndex,
                               index,
@@ -386,7 +386,7 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                           <Input
                             type="checkbox"
                             checked={run.done}
-                            onChange={(e) =>
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                               updateRun(
                                 weekIndex,
                                 index,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,19 +1,52 @@
 import * as React from "react";
 import { Label } from "@components/ui";
 
+export type InputChangeHandler =
+  | ((name: string, value: string) => void)
+  | ((e: React.ChangeEvent<HTMLInputElement>) => void);
+
 export interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> {
-  label: string;
-  name: string;
-  value: string | number | undefined;
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
+  label?: string;
+  name?: string;
+  value?: string | number;
   editing?: boolean;
-  onChange: (name: string, value: string) => void;
+  onChange?: InputChangeHandler;
   className?: string;
 }
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ label, name, value, editing = true, onChange, className = "", ...inputProps }, ref) => {
-    return (
+  (
+    { label, name, value, editing = true, onChange, className = "", ...inputProps },
+    ref
+  ) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!onChange) return;
+      if (onChange.length > 1) {
+        (onChange as (name: string, value: string) => void)(
+          name ?? "",
+          e.target.value
+        );
+      } else {
+        (onChange as React.ChangeEventHandler<HTMLInputElement>)(e);
+      }
+    };
+
+    const inputElement = editing ? (
+      <input
+        id={name}
+        name={name}
+        value={value}
+        onChange={handleChange}
+        ref={ref}
+        className={`mt-1 h-10 w-full rounded-md border border-accent-2 bg-accent-2 opacity-80 px-2 py-1 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2 ${className}`}
+        {...inputProps}
+      />
+    ) : (
+      <p className="mt-1 text-foreground dark:text-foreground">{value}</p>
+    );
+
+    return label ? (
       <div className="space-y-1 w-full">
         <Label htmlFor={name} className="block font-medium">
           {label}
@@ -21,21 +54,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             <span className="text-brand-orange-dark ml-1">*</span>
           )}
         </Label>
-
-        {editing ? (
-          <input
-            id={name}
-            name={name}
-            value={value}
-            onChange={(e) => onChange(name, e.target.value)}
-            ref={ref}
-            className={`mt-1 h-10 w-full rounded-md border border-accent-2 bg-accent-2 opacity-80 px-2 py-1 text-sm text-foreground ring-offset-background focus:outline-none focus:ring-2 focus:ring-accent-2 focus:ring-offset-2 ${className}`}
-            {...inputProps}
-          />
-        ) : (
-          <p className="mt-1 text-foreground dark:text-foreground">{value}</p>
-        )}
+        {inputElement}
       </div>
+    ) : (
+      inputElement
     );
   }
 );


### PR DESCRIPTION
## Summary
- adjust Input component props to support optional label/name
- allow onChange handler to accept either `(name, value)` or the native change event

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68524f8888608324938438328330e559