### PR TITLE
Add post counters

### DIFF
--- a/src/app/api/social/profile/[username]/route.ts
+++ b/src/app/api/social/profile/[username]/route.ts
@@ -14,7 +14,7 @@ export async function GET(_req: NextRequest, ctx: { params: { username: string }
             _count: { select: { runs: true } },
           },
         },
-        _count: { select: { followers: true, following: true } },
+        _count: { select: { followers: true, following: true, posts: true } },
       },
     });
     if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -37,6 +37,7 @@ export async function GET(_req: NextRequest, ctx: { params: { username: string }
       totalDistance: total._sum.distance ?? 0,
       followerCount: profile._count.followers,
       followingCount: profile._count.following,
+      postCount: profile._count.posts,
     };
 
     return NextResponse.json(data);

--- a/src/app/api/social/profile/byUser/[id]/route.ts
+++ b/src/app/api/social/profile/byUser/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
         user: {
           select: { name: true, avatarUrl: true, _count: { select: { runs: true } } },
         },
-        _count: { select: { followers: true, following: true } },
+        _count: { select: { followers: true, following: true, posts: true } },
       },
     });
     if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -33,6 +33,7 @@ export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
       totalDistance: total._sum.distance ?? 0,
       followerCount: profile._count.followers,
       followingCount: profile._count.following,
+      postCount: profile._count.posts,
     };
 
     return NextResponse.json(data);

--- a/src/app/api/social/search/route.ts
+++ b/src/app/api/social/search/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest) {
       },
       include: {
         user: { select: { name: true, avatarUrl: true, _count: { select: { runs: true } } } },
-        _count: { select: { followers: true, following: true } },
+        _count: { select: { followers: true, following: true, posts: true } },
       },
       take: 10,
     });
@@ -42,6 +42,7 @@ export async function GET(req: NextRequest) {
           totalDistance: total._sum.distance ?? 0,
           followerCount: p._count.followers,
           followingCount: p._count.following,
+          postCount: p._count.posts,
         };
       })
     );

--- a/src/app/social/groups/[id]/page.tsx
+++ b/src/app/social/groups/[id]/page.tsx
@@ -118,6 +118,7 @@ export default function GroupPage() {
             Created {new Date(group.createdAt).toLocaleDateString()}
           </p>
           <p className="text-sm">Members: {group.memberCount}</p>
+          <p className="text-sm">Posts: {group.postCount}</p>
           {group.totalDistance !== undefined && (
             <p className="text-sm">
               Total Distance: {group.totalDistance.toFixed(2)} mi

--- a/src/components/__tests__/ProfileInfoCard.test.tsx
+++ b/src/components/__tests__/ProfileInfoCard.test.tsx
@@ -15,6 +15,7 @@ const profile: SocialProfile = {
   updatedAt: new Date("2024-01-02"),
   name: "Runner",
   runCount: 5,
+  postCount: 2,
   totalDistance: 20,
   followerCount: 3,
   followingCount: 4,
@@ -30,6 +31,7 @@ describe("ProfileInfoCard", () => {
     render(<ProfileInfoCard profile={profile} user={user} isSelf />);
     expect(screen.getByRole("heading", { name: /runner/i })).toBeInTheDocument();
     expect(screen.getByText(/5 runs/)).toBeInTheDocument();
+    expect(screen.getByText(/2 posts/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /edit/i })).toBeInTheDocument();
   });
 });

--- a/src/components/social/GroupCard.tsx
+++ b/src/components/social/GroupCard.tsx
@@ -27,6 +27,7 @@ export default function GroupCard({ group }: Props) {
         </div>
         <div className="flex flex-col items-end text-sm text-foreground opacity-60 gap-1">
           <span>{group.memberCount ?? 0} members</span>
+          <span>{group.postCount ?? 0} posts</span>
           {group.private && <Badge variant="secondary">Private</Badge>}
         </div>
       </div>

--- a/src/components/social/ProfileInfoCard.tsx
+++ b/src/components/social/ProfileInfoCard.tsx
@@ -51,6 +51,11 @@ export default function ProfileInfoCard({ profile, user, isSelf }: Props) {
           </div>
           <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
             <span className="text-lg font-semibold">
+              {profile.postCount ?? 0} posts
+            </span>
+          </div>
+          <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
+            <span className="text-lg font-semibold">
               {profile.totalDistance ?? 0} mi
             </span>
           </div>

--- a/src/maratypes/social.ts
+++ b/src/maratypes/social.ts
@@ -15,6 +15,7 @@ export interface SocialProfile {
   totalDistance?: number;
   followerCount?: number;
   followingCount?: number;
+  postCount?: number;
 }
 
 export interface RunPost {


### PR DESCRIPTION
## Summary
- show post count for profiles and groups
- expose profile postCount via API
- display posts metric in ProfileInfoCard and Group UI
- update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852cfdee6788324bc77fe9a041c0fe2