### PR TITLE
Make comment usernames link to profiles

### DIFF
--- a/src/components/social/CommentSection.tsx
+++ b/src/components/social/CommentSection.tsx
@@ -5,6 +5,7 @@ import { listComments, addComment } from "@lib/api/social";
 import type { Comment } from "@maratypes/social";
 import { Button, Input, Spinner } from "@components/ui";
 import Image from "next/image";
+import Link from "next/link";
 import { MessageCircle } from "lucide-react";
 
 interface Props {
@@ -93,9 +94,16 @@ export default function CommentSection({
                   className="w-6 h-6 rounded-full object-cover border border-brand-to bg-brand-from"
                 />
                 <p>
-                  <span className="font-semibold">
-                    {c.socialProfile?.username}
-                  </span>{" "}
+                  {c.socialProfile?.username ? (
+                    <Link
+                      href={`/u/${c.socialProfile.username}`}
+                      className="font-semibold hover:underline"
+                    >
+                      {c.socialProfile.username}
+                    </Link>
+                  ) : (
+                    <span className="font-semibold">{c.socialProfile?.username}</span>
+                  )}{" "}
                   {c.text}
                 </p>
               </div>

--- a/src/components/social/CommentSection.tsx
+++ b/src/components/social/CommentSection.tsx
@@ -49,7 +49,7 @@ export default function CommentSection({
     setSubmitting(true);
     try {
       const comment = await addComment(postId, profile.id, text.trim());
-      setComments((c) => [...c, comment]);
+      setComments((c) => [...c, { ...comment, socialProfile: profile }]);
       setCount((c) => c + 1);
       onCommentAdded?.();
       setText("");

--- a/src/components/social/ProfileInfoCard.tsx
+++ b/src/components/social/ProfileInfoCard.tsx
@@ -50,24 +50,27 @@ export default function ProfileInfoCard({ profile, user, isSelf }: Props) {
       <div className="w-full flex flex-col sm:flex-row justify-center items-center text-center gap-4 text-sm text-muted-foreground">
         <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
           <span className="text-lg font-semibold">
-            {profile.runCount ?? 0}{" "}<span className="text-sm">runs</span>
+            {profile.runCount ?? 0} runs
           </span>
         </div>
         <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
           <span className="text-lg font-semibold">
-            {profile.totalDistance ?? 0} <span className="text-sm">mi</span>
+            {profile.postCount ?? 0} posts
           </span>
         </div>
         <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
           <span className="text-lg font-semibold">
-            {profile.followerCount ?? 0}{" "}
-            <span className="text-sm">followers</span>
+            {profile.totalDistance ?? 0} mi
           </span>
         </div>
         <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
           <span className="text-lg font-semibold">
-            {profile.followingCount ?? 0}{" "}
-            <span className="text-sm">following</span>
+            {profile.followerCount ?? 0} followers
+          </span>
+        </div>
+        <div className="flex items-baseline justify-center w-full sm:w-auto gap-1">
+          <span className="text-lg font-semibold">
+            {profile.followingCount ?? 0} following
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- display post count in `ProfileInfoCard`
- show counts without nested spans so tests pass
- link usernames in `CommentSection` to their profile pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68530853db7883249365bfcf5006b2ef