### PR TITLE
Move follow button into profile card

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,9 +1,8 @@
 import { notFound } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../api/auth/[...nextauth]/route";
-import type { SocialProfile, RunPost } from "@maratypes/social";
+import type { SocialProfile } from "@maratypes/social";
 import type { Run } from "@maratypes/run";
-import FollowUserButton from "@components/social/FollowUserButton";
 import ProfileInfoCard from "@components/social/ProfileInfoCard";
 import PostList from "@components/social/PostList";
 import { prisma } from "@lib/prisma";
@@ -108,7 +107,6 @@ export default async function UserProfilePage({ params }: Props) {
             following={data.following}
             runs={data.runs}
           />
-          {!isSelf && <FollowUserButton profileId={data.id} />}
         </div>
         <section className="w-full space-y-6">
           <h2 className="text-xl font-semibold">Posts</h2>

--- a/src/components/social/ProfileInfoCard.tsx
+++ b/src/components/social/ProfileInfoCard.tsx
@@ -7,6 +7,7 @@ import type { SocialProfile } from "@maratypes/social";
 import type { User } from "@maratypes/user";
 import type { Run } from "@maratypes/run";
 import { Card, Button, Dialog, DialogContent } from "@components/ui";
+import FollowUserButton from "@components/social/FollowUserButton";
 
 interface Props {
   profile: SocialProfile;
@@ -103,7 +104,7 @@ export default function ProfileInfoCard({
           </span>
         </div>
       </div>
-      {isSelf && (
+      {isSelf ? (
         <Button
           asChild
           size="sm"
@@ -111,6 +112,10 @@ export default function ProfileInfoCard({
         >
           <Link href="/social/profile/edit">Edit</Link>
         </Button>
+      ) : (
+        <div className="absolute top-4 right-4">
+          <FollowUserButton profileId={profile.id} />
+        </div>
       )}
     </Card>
 


### PR DESCRIPTION
## Summary
- render FollowUserButton inside ProfileInfoCard
- remove extra FollowUserButton from user profile page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854ba9c66348324b78427dc82c4b464