### PR TITLE
Fix Start Now activation

### DIFF
--- a/src/app/plans/[id]/page.tsx
+++ b/src/app/plans/[id]/page.tsx
@@ -74,6 +74,25 @@ export default function PlanPage({ params }: PageProps) {
     }
   };
 
+  const handleStartNow = async (updated: RunningPlan["planData"]) => {
+    if (!plan?.id) return;
+    try {
+      const result: RunningPlan = await updateRunningPlan(plan.id, {
+        planData: updated,
+        startDate: updated.startDate,
+        endDate: updated.endDate,
+        active: true,
+      });
+      setPlan(result);
+      setPlanData(updated);
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("activePlanChanged"));
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <main className="w-full px-4 sm:px-6 lg:px-8 py-4 space-y-4">
       <h1 className="text-2xl font-bold mb-4">{plan.name}</h1>
@@ -84,6 +103,7 @@ export default function PlanPage({ params }: PageProps) {
           allowEditable
           onPlanChange={setPlanData}
           onSave={handleSave}
+          onStartNow={handleStartNow}
         />
       )}
     </main>

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../api/auth/[...nextauth]/route";
-import type { SocialProfile, RunPost } from "@maratypes/social";
+import type { SocialProfile } from "@maratypes/social";
 import type { Run } from "@maratypes/run";
 import FollowUserButton from "@components/social/FollowUserButton";
 import ProfileInfoCard from "@components/social/ProfileInfoCard";

--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -40,6 +40,11 @@ interface RunningPlanDisplayProps {
    * existing plan. The updated plan data is provided.
    */
   onSave?: (planData: RunningPlanData) => Promise<void> | void;
+  /**
+   * Callback invoked when the "Start Now" button is clicked. Useful for
+   * persisting the new start date or toggling active state.
+   */
+  onStartNow?: (planData: RunningPlanData) => Promise<void> | void;
 }
 
 const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
@@ -52,6 +57,7 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
   onPlanChange,
   onPlanNameChange,
   onSave,
+  onStartNow,
 }) => {
   const { profile: user } = useUser();
   const [editingName, setEditingName] = useState(false);
@@ -101,14 +107,16 @@ const RunningPlanDisplay: React.FC<RunningPlanDisplayProps> = ({
     onPlanChange({ ...planData, endDate: date, schedule: sched });
   };
 
-  const startToday = () => {
+  const startToday = async () => {
     const today = new Date().toISOString().slice(0, 10);
-    if (!onPlanChange) return;
     const updated = assignDatesToPlan(planData, {
       startDate: today,
       endDate: planData.endDate,
     });
-    onPlanChange(updated);
+    onPlanChange?.(updated);
+    if (onStartNow) {
+      await onStartNow(updated);
+    }
   };
 
   const handleSave = async () => {


### PR DESCRIPTION
## Summary
- ensure Start Now persists and activates running plan
- expose onStartNow callback in RunningPlanDisplay
- fix lint issue in profile page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854ba62b2048324b834467485c963e0