### PR TITLE
Fix checkbox styling in RunningPlanDisplay

### DIFF
--- a/src/components/training/RunningPlanDisplay.tsx
+++ b/src/components/training/RunningPlanDisplay.tsx
@@ -7,7 +7,7 @@ import { RunningPlanData, WeekPlan, PlannedRun } from "@maratypes/runningPlan";
 import { DayOfWeek } from "@maratypes/basics";
 import { setDayForRunType } from "@utils/running/setRunDay";
 import { parsePace, formatPace } from "@utils/running/paces";
-import { Button } from "@components/ui";
+import { Button, Checkbox, Label } from "@components/ui";
 import { Input } from "@components/ui/input";
 import { SelectField } from "@components/ui/FormField";
 import { useRouter } from "next/navigation";
@@ -422,22 +422,22 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                           className="border p-1 rounded text-foreground w-full"
                         />
                       </label>
-                      <label className="block">
-                        <Input
-                          type="checkbox"
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={`run-${weekIndex}-${index}-edit-done`}
                           checked={run.done || false}
-                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                            updateRun(
-                              weekIndex,
-                              index,
-                              "done",
-                              e.target.checked
-                            )
+                          onCheckedChange={(checked: boolean) =>
+                            updateRun(weekIndex, index, "done", Boolean(checked))
                           }
-                          className="mr-2"
+                          className="h-4 w-4 bg-foreground text-background"
                         />
-                        Mark done
-                      </label>
+                        <Label
+                          htmlFor={`run-${weekIndex}-${index}-edit-done`}
+                          className="text-sm"
+                        >
+                          Mark done
+                        </Label>
+                      </div>
                     </div>
                   ) : (
                     <>
@@ -468,23 +468,23 @@ const CollapsibleWeek: React.FC<CollapsibleWeekProps> = ({
                         </p>
                       )}
                       {typeof run.done !== "undefined" && (
-                        <p>
-                          <Input
-                            type="checkbox"
+                        <div className="flex items-center gap-2">
+                          <Checkbox
+                            id={`run-${weekIndex}-${index}-view-done`}
                             checked={run.done}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                              updateRun(
-                                weekIndex,
-                                index,
-                                "done",
-                                e.target.checked
-                              )
+                            onCheckedChange={(checked: boolean) =>
+                              updateRun(weekIndex, index, "done", Boolean(checked))
                             }
-                            className="mr-2"
+                            className="h-4 w-4 bg-foreground text-background"
                             disabled={editable}
                           />
-                          <span>Done</span>
-                        </p>
+                          <Label
+                            htmlFor={`run-${weekIndex}-${index}-view-done`}
+                            className="text-sm"
+                          >
+                            Done
+                          </Label>
+                        </div>
                       )}
                     </>
                   )}


### PR DESCRIPTION
## Summary
- fix style of done checkbox in RunningPlanDisplay by using the Checkbox component

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities in src/app/social/page.tsx)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e1aece0083248cfa5851c491ab68