### PR TITLE
Improve profile stats modal

### DIFF
--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -57,7 +57,7 @@ export default function SocialHomePage() {
     return (
       <main className="w-full px-4 sm:px-6 lg:px-8 py-6 space-y-2">
         <div className="flex flex-col items-center text-center pt-8 space-y-4">
-          <h3>You don't have a social profile yet!</h3>
+          <h3>You don&apos;t have a social profile yet!</h3>
           <Button
             asChild
             className="text-foreground bg-transparent no-underline transition-colors hover:text-background hover:no-underline hover:bg-brand-from"

--- a/src/components/social/ProfileInfoCard.tsx
+++ b/src/components/social/ProfileInfoCard.tsx
@@ -6,7 +6,8 @@ import { useState } from "react";
 import type { SocialProfile } from "@maratypes/social";
 import type { User } from "@maratypes/user";
 import type { Run } from "@maratypes/run";
-import { Card, Button, Dialog, DialogContent } from "@components/ui";
+import { Card, Button } from "@components/ui";
+import ProfileStatsModal from "@components/social/ProfileStatsModal";
 import FollowUserButton from "@components/social/FollowUserButton";
 
 interface Props {
@@ -119,62 +120,64 @@ export default function ProfileInfoCard({
       )}
     </Card>
 
-    <Dialog open={showRuns} onOpenChange={setShowRuns}>
-      <DialogContent>
-        <h3 className="text-lg font-semibold mb-2">Runs</h3>
-        {runs && runs.length > 0 ? (
-          <ul className="list-disc ml-4 space-y-1 text-left">
-            {runs.map((r) => (
-              <li key={r.id}>
-                {r.name || new Date(r.date).toLocaleDateString()} - {r.distance}
-                {" "}
-                {r.distanceUnit}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>No runs found.</p>
-        )}
-      </DialogContent>
-    </Dialog>
+    <ProfileStatsModal
+      title="Runs"
+      open={showRuns}
+      onOpenChange={setShowRuns}
+    >
+      {runs && runs.length > 0 ? (
+        <ul className="list-disc ml-4 space-y-1 text-left">
+          {runs.map((r) => (
+            <li key={r.id}>
+              {r.name || new Date(r.date).toLocaleDateString()} - {r.distance}{" "}
+              {r.distanceUnit}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No runs found.</p>
+      )}
+    </ProfileStatsModal>
 
-    <Dialog open={showFollowers} onOpenChange={setShowFollowers}>
-      <DialogContent>
-        <h3 className="text-lg font-semibold mb-2">Followers</h3>
-        {followers && followers.length > 0 ? (
-          <ul className="space-y-1">
-            {followers.map((f) => (
-              <li key={f.id}>
-                <Link href={`/u/${f.username}`} className="underline">
-                  @{f.username}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>No followers yet.</p>
-        )}
-      </DialogContent>
-    </Dialog>
+    <ProfileStatsModal
+      title="Followers"
+      open={showFollowers}
+      onOpenChange={setShowFollowers}
+    >
+      {followers && followers.length > 0 ? (
+        <ul className="space-y-1">
+          {followers.map((f) => (
+            <li key={f.id}>
+              <Link href={`/u/${f.username}`} className="underline">
+                @{f.username}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No followers yet.</p>
+      )}
+    </ProfileStatsModal>
 
-    <Dialog open={showFollowing} onOpenChange={setShowFollowing}>
-      <DialogContent>
-        <h3 className="text-lg font-semibold mb-2">Following</h3>
-        {following && following.length > 0 ? (
-          <ul className="space-y-1">
-            {following.map((f) => (
-              <li key={f.id}>
-                <Link href={`/u/${f.username}`} className="underline">
-                  @{f.username}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>Not following anyone.</p>
-        )}
-      </DialogContent>
-    </Dialog>
+    <ProfileStatsModal
+      title="Following"
+      open={showFollowing}
+      onOpenChange={setShowFollowing}
+    >
+      {following && following.length > 0 ? (
+        <ul className="space-y-1">
+          {following.map((f) => (
+            <li key={f.id}>
+              <Link href={`/u/${f.username}`} className="underline">
+                @{f.username}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>Not following anyone.</p>
+      )}
+    </ProfileStatsModal>
     </>
   );
 }

--- a/src/components/social/ProfileStatsModal.tsx
+++ b/src/components/social/ProfileStatsModal.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Dialog, DialogContent } from "@components/ui";
+import { Button } from "@components/ui/button";
+import { X } from "lucide-react";
+
+interface Props {
+  title: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export default function ProfileStatsModal({
+  title,
+  open,
+  onOpenChange,
+  children,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="relative max-w-md">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Close"
+          onClick={() => onOpenChange(false)}
+          className="absolute top-2 right-2"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+        <h3 className="text-lg font-semibold text-center mb-2">{title}</h3>
+        <div className="max-h-60 overflow-y-auto text-sm space-y-1">
+          {children}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ProfileStatsModal` component for reusable list modals
- use `ProfileStatsModal` in `ProfileInfoCard` for runs, followers, and following
- escape apostrophe in social profile message

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e574a6e88324b6d054a69a1fe055