### PR TITLE
Fix profile stats modal accessibility

### DIFF
--- a/src/components/social/ProfileStatsModal.tsx
+++ b/src/components/social/ProfileStatsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Dialog, DialogContent } from "@components/ui";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@components/ui";
 import { Button } from "@components/ui/button";
 import { X } from "lucide-react";
 
@@ -29,7 +29,9 @@ export default function ProfileStatsModal({
         >
           <X className="h-4 w-4" />
         </Button>
-        <h3 className="text-lg font-semibold text-center mb-2">{title}</h3>
+        <DialogHeader>
+          <DialogTitle className="mb-2">{title}</DialogTitle>
+        </DialogHeader>
         <div className="max-h-60 overflow-y-auto text-sm space-y-1">
           {children}
         </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -45,3 +45,29 @@ export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLD
 export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
 );
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export const DialogClose = DialogPrimitive.Close;


### PR DESCRIPTION
## Summary
- add `DialogTitle` and `DialogDescription` components to our UI library
- update ProfileStatsModal to use `DialogHeader`/`DialogTitle`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e7d092b08324b42df503cb99a970