### PR TITLE
Add profile info tooltips

### DIFF
--- a/src/components/profile/BasicInfoSection.tsx
+++ b/src/components/profile/BasicInfoSection.tsx
@@ -1,4 +1,4 @@
-import { TextField, SelectField, AvatarUpload } from "@components/ui";
+import { TextField, SelectField, AvatarUpload, InfoTooltip } from "@components/ui";
 import { User } from "@maratypes/user";
 import styles from "./Section.module.css";
 import type { Gender } from "@maratypes/user";
@@ -90,7 +90,12 @@ export default function BasicInfoSection({
           />
           {showVDOTField && (
             <TextField
-              label="VDOT"
+              label={
+                <>
+                  VDOT
+                  <InfoTooltip content="VDOT estimates your running fitness based on race times." />
+                </>
+              }
               name="VDOT"
               type="number"
               value={formData.VDOT ?? ""}
@@ -140,7 +145,10 @@ export default function BasicInfoSection({
             </dd>
           </div>
           <div>
-            <dt className={styles.label}>VDOT</dt>
+            <dt className={styles.label}>
+              VDOT
+              <InfoTooltip content="VDOT estimates your running fitness based on race times." />
+            </dt>
             <dd className={styles.value}>{formData.VDOT ?? "N/A"}</dd>
           </div>
         </dl>

--- a/src/components/ui/FormField/TextField.tsx
+++ b/src/components/ui/FormField/TextField.tsx
@@ -6,7 +6,7 @@ import { Input, Label } from "@components/ui";
 
 export interface TextFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
-  label: string;
+  label: React.ReactNode;
   name: string;
   value: string | number;
   editing?: boolean;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -28,3 +28,4 @@ export * from './select';
 export { default as AvatarUpload } from './avatar-upload';
 export { default as PhotoUpload } from "./photo-upload";
 export * from './spinner';
+export { default as InfoTooltip } from './info-tooltip';

--- a/src/components/ui/info-tooltip.tsx
+++ b/src/components/ui/info-tooltip.tsx
@@ -1,0 +1,34 @@
+import { HelpCircle } from "lucide-react";
+import { cn } from "@lib/utils/cn";
+import {
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+  TooltipContent,
+} from "@components/ui";
+import React from "react";
+
+interface InfoTooltipProps {
+  content: React.ReactNode;
+  className?: string;
+  iconClassName?: string;
+}
+
+export default function InfoTooltip({
+  content,
+  className,
+  iconClassName,
+}: InfoTooltipProps) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <TooltipRoot>
+        <TooltipTrigger asChild>
+          <HelpCircle
+            className={cn("ml-1 h-4 w-4 text-muted-foreground", iconClassName)}
+          />
+        </TooltipTrigger>
+        <TooltipContent className={cn(className)}>{content}</TooltipContent>
+      </TooltipRoot>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add `InfoTooltip` component
- extend `TextField` to support `ReactNode` labels
- show VDOT tooltip on profile form
- re-export new component from UI index

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858bbb5702483248890266477b22db7