### PR TITLE
Add device connection storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,19 @@ Prisma Studio is a web-based GUI that makes it easy to view and edit your databa
    ```
 
 2. This command will open a new browser window where you can navigate your database tables and records.
+
+## Device Connections (Experimental)
+
+You can link a Garmin watch, Apple Watch, or Apple Health to your profile.
+The helper in `src/lib/api/device` posts a connection token to
+`/api/devices/connect`. The token is stored and associated with your user.
+
+```
+import { connectDevice } from "@lib/api/device";
+
+await connectDevice({ provider: "garmin", token, userId });
+```
+
+For Garmin devices, refer to Garmin's developer portal for details on obtaining
+OAuth credentials. Apple Watch and Apple Health integrations rely on HealthKit
+and WatchKit; see Apple's documentation for authorization steps.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,12 @@ enum Gender {
   Other
 }
 
+enum DeviceProvider {
+  appleHealth
+  appleWatch
+  garmin
+}
+
 model User {
   id                           String               @id @default(uuid())
   name                         String
@@ -258,4 +264,14 @@ model RunGroupMember {
   socialProfile SocialProfile @relation(fields: [socialProfileId], references: [id])
 
   @@id([groupId, socialProfileId])
+}
+
+model DeviceConnection {
+  id        String         @id @default(uuid())
+  provider  DeviceProvider
+  token     String
+  userId    String
+  createdAt DateTime       @default(now())
+
+  user User @relation(fields: [userId], references: [id])
 }

--- a/src/app/api/devices/connect/route.ts
+++ b/src/app/api/devices/connect/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@lib/prisma";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { provider, token, userId } = body;
+    if (!provider || !token || !userId) {
+      return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
+    }
+
+    await prisma.deviceConnection.create({
+      data: { provider, token, userId },
+    });
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch (error) {
+    console.error("Error connecting device", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error connecting device" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/api/__tests__/device.test.ts
+++ b/src/lib/api/__tests__/device.test.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import axios from "axios";
+import { connectDevice } from "../device";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("device api helpers", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("connectDevice posts data", async () => {
+    mockedAxios.post.mockResolvedValue({ data: { success: true } });
+    const payload = { provider: "garmin", token: "abc", userId: "1" } as any;
+    const res = await connectDevice(payload);
+    expect(mockedAxios.post).toHaveBeenCalledWith("/api/devices/connect", payload);
+    expect(res).toEqual({ success: true });
+  });
+});

--- a/src/lib/api/device/index.ts
+++ b/src/lib/api/device/index.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import type { DeviceProvider } from "@maratypes/device";
+
+export interface ConnectDevicePayload {
+  provider: DeviceProvider;
+  token: string;
+  userId: string;
+}
+
+export const connectDevice = async (
+  data: ConnectDevicePayload
+): Promise<{ success: boolean }> => {
+  const res = await axios.post("/api/devices/connect", data);
+  return res.data as { success: boolean };
+};

--- a/src/maratypes/device.ts
+++ b/src/maratypes/device.ts
@@ -1,0 +1,9 @@
+export type DeviceProvider = "appleHealth" | "appleWatch" | "garmin";
+
+export interface DeviceConnection {
+  id: string;
+  provider: DeviceProvider;
+  token: string;
+  userId: string;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- store device tokens in a new `DeviceConnection` model
- update device connect API route to persist the connection
- allow `connectDevice` helper to return success value
- expand unit test
- document linking Garmin and Apple devices

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859de49d9f08324812306ea3846ffe2