### PR TITLE
Add tcx parsing utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "fast-xml-parser": "^5.2.5",
         "framer-motion": "^12.16.0",
         "lucide-react": "^0.514.0",
         "next": "15.2.3",
@@ -6447,6 +6448,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -11258,6 +11277,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fast-xml-parser": "^5.2.5",
     "framer-motion": "^12.16.0",
     "lucide-react": "^0.514.0",
     "next": "15.2.3",

--- a/src/lib/utils/__tests__/parseTcx.test.ts
+++ b/src/lib/utils/__tests__/parseTcx.test.ts
@@ -1,0 +1,26 @@
+import { parseTcx } from "../running/parseTcx";
+
+const sample = `<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase>
+  <Activities>
+    <Activity Sport="Running">
+      <Id>2024-05-01T10:00:00Z</Id>
+      <Lap StartTime="2024-05-01T10:00:00Z">
+        <TotalTimeSeconds>1800</TotalTimeSeconds>
+        <DistanceMeters>5000</DistanceMeters>
+      </Lap>
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>`;
+
+describe("parseTcx", () => {
+  it("parses a simple tcx run", () => {
+    const run = parseTcx(sample, { userId: "user1", distanceUnit: "kilometers" });
+    expect(run.date.toISOString()).toBe("2024-05-01T10:00:00.000Z");
+    expect(run.duration).toBe("00:30:00");
+    expect(run.distance).toBe(5);
+    expect(run.distanceUnit).toBe("kilometers");
+    expect(run.pace?.pace).toBe("06:00");
+    expect(run.pace?.unit).toBe("kilometers");
+  });
+});

--- a/src/lib/utils/running/index.ts
+++ b/src/lib/utils/running/index.ts
@@ -1,0 +1,1 @@
+export * from './parseTcx';

--- a/src/lib/utils/running/parseTcx.ts
+++ b/src/lib/utils/running/parseTcx.ts
@@ -1,0 +1,63 @@
+import { XMLParser } from "fast-xml-parser";
+import type { Run } from "@maratypes/run";
+import { DistanceUnit } from "@maratypes/basics";
+import calculatePace from "./calculatePace";
+
+export interface ParseTcxOptions {
+  userId: string;
+  shoeId?: string;
+  distanceUnit?: DistanceUnit;
+}
+
+function formatSeconds(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = Math.round(seconds % 60);
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+}
+
+export function parseTcx(tcx: string, options: ParseTcxOptions): Run {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  const data = parser.parse(tcx);
+
+  const activity =
+    data?.TrainingCenterDatabase?.Activities?.Activity;
+  if (!activity) {
+    throw new Error("Invalid TCX data");
+  }
+
+  const laps = Array.isArray(activity.Lap) ? activity.Lap : [activity.Lap];
+  let totalTime = 0;
+  let totalDistanceMeters = 0;
+
+  for (const lap of laps) {
+    totalTime += parseFloat(lap.TotalTimeSeconds);
+    totalDistanceMeters += parseFloat(lap.DistanceMeters);
+  }
+
+  const date = new Date(activity.Id);
+  const distanceUnit = options.distanceUnit ?? "kilometers";
+  const distanceKm = totalDistanceMeters / 1000;
+  const distance =
+    distanceUnit === "miles"
+      ? parseFloat((distanceKm / 1.60934).toFixed(2))
+      : parseFloat(distanceKm.toFixed(2));
+  const duration = formatSeconds(totalTime);
+  const pace = calculatePace(duration, distance);
+
+  return {
+    date,
+    duration,
+    distance,
+    distanceUnit,
+    pace: { unit: distanceUnit, pace },
+    trainingEnvironment: "outdoor",
+    userId: options.userId,
+    shoeId: options.shoeId,
+    name: activity.Notes ?? undefined,
+  };
+}
+
+export default parseTcx;


### PR DESCRIPTION
## Summary
- add `fast-xml-parser` for reading TCX files
- implement `parseTcx` utility to convert TCX XML into a `Run`
- export running utilities via new index file
- test TCX parser

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859de30a0f88324a3c93790e5391149